### PR TITLE
Validation extension test should fail on `DefinitionException` not `DeploymentException`

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/validation/ValidationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/validation/ValidationTest.java
@@ -1,5 +1,6 @@
 package org.jboss.cdi.tck.tests.build.compatible.extensions.validation;
 
+import jakarta.enterprise.inject.spi.DefinitionException;
 import jakarta.enterprise.inject.spi.DeploymentException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
@@ -14,7 +15,7 @@ import org.testng.annotations.Test;
 @SpecVersion(spec = "cdi", version = "4.0")
 public class ValidationTest extends AbstractTest {
     @Deployment
-    @ShouldThrowException(DeploymentException.class)
+    @ShouldThrowException(DefinitionException.class)
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder()
                 .withTestClassPackage(ValidationTest.class)


### PR DESCRIPTION
My understanding is that the compile-time errors tests should fail with `DefinitionException` and runtime/deploy errors with `DeploymentException`. Because extensions are executed at the compile-time it should fail on `DefinitionException`.

FYI @graemerocher 