### PR TITLE
Disable the tck-audit profile by default so that the org.jboss.test-a…

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -21,7 +21,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: "Maven install(staging)"
         run: |
-          mvn clean install -Pstaging -B -V
+          mvn clean install -Pstaging -B -V -DgenerateSource
       - name: "Maven install"
         run: |
-          mvn clean install -B -V
+          mvn clean install -B -V -DgenerateSource

--- a/README.md
+++ b/README.md
@@ -3,9 +3,28 @@
 
 Check out the [TCK Reference Guide](https://eclipse-ee4j.github.io/cdi-tck/) to get acquainted with the CDI TCK and learn how to execute and debug it.
 
+## Building CDI TCK artifacts
+To build the CDI TCK artifacts, use:
+
+`mvn -DgenerateSource install`
+
+or when compiling against staged Jakarta artifacts:
+
+`mvn -DgenerateSource -Pstaging install`
+
+## Building the CDI TCK distribution
+The CDI TCK distribution artifact is built by specifing an additional `-Drelease` property to build the TCK reference
+documentation and distribution bundle, e.g.:
+
+`mvn -DgenerateSource -Drelease install`
+
+## Eclipse Continuous Integration Environment
+The Eclipse continuous integration environment interface for the CDI project is located at https://ci.eclipse.org/cdi/
+The https://github.com/jakartaee/cdi/wiki/Eclipse-CI-Release-Jobs page describes the jobs found there.
+
 ## Sources in GIT
 
-Master branch contains the work-in-progress on CDI TCK 4.0
+Master branch contains the CDI TCK 4.0
 
 ### Source Layout
 
@@ -20,3 +39,4 @@ Master branch contains the work-in-progress on CDI TCK 4.0
 * lang-model - A standalone test suite for the CDI language model; see its [README](./lang-model/README.adoc)
 * web - The extra tests that depend on the web profile and full platform
 * README.md - this doc
+* settings.xml - 

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -219,7 +219,7 @@
             <id>tck-audit</id>
             <activation>
                 <property>
-                    <name>!skipTckAudit</name>
+                    <name>generateSource</name>
                 </property>
             </activation>
             <dependencies>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -299,7 +299,7 @@
             <id>tck-audit</id>
             <activation>
                 <property>
-                    <name>!skipTckAudit</name>
+                    <name>generateSource</name>
                 </property>
             </activation>
             <dependencies>


### PR DESCRIPTION
…udit dependencies are not seen by default in the TCK test artifact dependencies.

The build needs -DgenerateSource to run with this change

Signed-off-by: Scott M Stark <starksm64@gmail.com>