### PR TITLE
Revert "Disable the tck-audit profile by default so that the org.jbos…

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -21,7 +21,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: "Maven install(staging)"
         run: |
-          mvn clean install -Pstaging -B -V -DtckAuditSourceGen
+          mvn clean install -Pstaging -B -V
       - name: "Maven install"
         run: |
-          mvn clean install -B -V -DtckAuditSourceGen
+          mvn clean install -B -V

--- a/README.md
+++ b/README.md
@@ -3,28 +3,9 @@
 
 Check out the [TCK Reference Guide](https://jakartaee.github.io/cdi-tck/) to get acquainted with the CDI TCK and learn how to execute and debug it.
 
-## Building CDI TCK artifacts
-To build the CDI TCK artifacts, use:
-
-`mvn -DtckAuditSourceGen install`
-
-or when compiling against staged Jakarta artifacts:
-
-`mvn -DtckAuditSourceGen -Pstaging install`
-
-## Building the CDI TCK distribution
-The CDI TCK distribution artifact is built by specifing an additional `-Drelease` property to build the TCK reference
-documentation and distribution bundle, e.g.:
-
-`mvn -DtckAuditSourceGen -Drelease install`
-
-## Eclipse Continuous Integration Environment
-The Eclipse continuous integration environment interface for the CDI project is located at https://ci.eclipse.org/cdi/
-The https://github.com/jakartaee/cdi/wiki/Eclipse-CI-Release-Jobs page describes the jobs found there.
-
 ## Sources in GIT
 
-Master branch contains the CDI TCK 4.0
+Master branch contains the work-in-progress on CDI TCK 4.0
 
 ### Source Layout
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,28 @@
 
 Check out the [TCK Reference Guide](https://jakartaee.github.io/cdi-tck/) to get acquainted with the CDI TCK and learn how to execute and debug it.
 
+## Building CDI TCK artifacts
+To build the CDI TCK artifacts, use:
+
+`mvn install`
+
+or when compiling against staged Jakarta artifacts:
+
+`mvn -Pstaging install`
+
+## Building the CDI TCK distribution
+The CDI TCK distribution artifact is built by specifing an additional `-Drelease` property to build the TCK reference
+documentation and distribution bundle, e.g.:
+
+`mvn -Drelease install`
+
+## Eclipse Continuous Integration Environment
+The Eclipse continuous integration environment interface for the CDI project is located at https://ci.eclipse.org/cdi/
+The https://github.com/jakartaee/cdi/wiki/Eclipse-CI-Release-Jobs page describes the jobs found there.
+
 ## Sources in GIT
 
-Master branch contains the work-in-progress on CDI TCK 4.0
+Master branch contains the CDI TCK 4.0
 
 ### Source Layout
 

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -215,14 +215,11 @@
     </build>
 
     <profiles>
-        <!-- This profile is needed to build the test artifact as it generates the spec SpecAssertion*/SpecVersion annotations.
-        It is disabled by default because the org.jboss.test-audit:* should not be dependencies of the test artifact.
-        -->
         <profile>
             <id>tck-audit</id>
             <activation>
                 <property>
-                    <name>tckAuditSourceGen</name>
+                    <name>!skipTckAudit</name>
                 </property>
             </activation>
             <dependencies>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -299,7 +299,7 @@
             <id>tck-audit</id>
             <activation>
                 <property>
-                    <name>tckAuditSourceGen</name>
+                    <name>!skipTckAudit</name>
                 </property>
             </activation>
             <dependencies>


### PR DESCRIPTION
…s.test-a… (#388)"

This reverts commit 22d9a76199356b8da8827ed76f415ef1ff45f107.

Fixes #383 


Puts us back in state where plain `mvn clean install` builds the whole project since we should no longer need jboss repo access to gain access to tck audit artifacts.