### PR TITLE
Fixed tests to disabling thrown of FailingHttpStatusCode exception

### DIFF
--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/async/ApplicationContextAsyncListenerTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/async/ApplicationContextAsyncListenerTest.java
@@ -78,6 +78,7 @@ public class ApplicationContextAsyncListenerTest extends AbstractTest {
     @SpecAssertion(section = APPLICATION_CONTEXT_EE, id = "ae")
     public void testApplicationContextActiveOnError() throws Exception {
         WebClient webClient = new WebClient();
+        webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
         webClient.getPage(getPath(AsyncServlet.TEST_ERROR));
         TextPage results = webClient.getPage(contextPath + "Status");
         assertTrue(results.getContent().contains("onError: true"));

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/ConversationDeterminationTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/ConversationDeterminationTest.java
@@ -59,6 +59,7 @@ public class ConversationDeterminationTest extends AbstractTest {
     public void testConversationDetermination() throws Exception {
 
         WebClient webClient = new WebClient();
+        webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
 
         // Begin long-running conversation
         TextPage cidPage = webClient.getPage(contextPath + "foo?action=begin");

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/async/RequestContextAsyncListenerTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/async/RequestContextAsyncListenerTest.java
@@ -86,6 +86,7 @@ public class RequestContextAsyncListenerTest extends AbstractTest {
     @SpecAssertion(section = REQUEST_CONTEXT_EE, id = "ad")
     public void testRequestContextActiveOnError() throws Exception {
         WebClient webClient = new WebClient();
+        webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
         webClient.getPage(getPath(AsyncServlet.TEST_ERROR));
         TextPage results = webClient.getPage(contextPath + "Status");
         assertTrue(results.getContent().contains("onError: true"));

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/async/SessionContextAsyncListenerTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/async/SessionContextAsyncListenerTest.java
@@ -82,6 +82,7 @@ public class SessionContextAsyncListenerTest extends AbstractTest {
     @SpecAssertions({ @SpecAssertion(section = SESSION_CONTEXT_EE, id = "ad") })
     public void testSessionContextActiveOnError() throws Exception {
         WebClient webClient = new WebClient();
+        webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
         webClient.getPage(getPath(AsyncServlet.TEST_ERROR));
         TextPage results = webClient.getPage(contextPath + "Status");
         assertTrue(results.getContent().contains("onError: true"));


### PR DESCRIPTION
The tests fixed here were designed to validate error page response. On some servers this is causing to thrown the FailingHttpStatusCode exception causing to fail the tests (Payara server is an example). This PR is to disable this behaviour that is part of the HtmlUnit implementation. This will help some servers to pass TCK by omitting the FailingHttpStatusCode exception

[challenge created](https://github.com/jakartaee/cdi-tck/issues/389)