### PR TITLE
Add test for injection of BeanContainer

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/injection/BeanContainerInjectionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/injection/BeanContainerInjectionTest.java
@@ -1,0 +1,50 @@
+package org.jboss.cdi.tck.tests.beanContainer.injection;
+
+import static org.jboss.cdi.tck.cdi.Sections.BEANCONTAINER;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Default;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.BeanContainer;
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecAssertions;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Simple test which verifies that we can provide {@link BeanContainer} as a built-in bean
+ */
+public class BeanContainerInjectionTest extends AbstractTest {
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder().withTestClassPackage(BeanContainerInjectionTest.class)
+                .withClasses(MyBean.class).build();
+    }
+
+    @Inject
+    MyBean myBean;
+
+    @Inject
+    Instance<Object> instance;
+
+    @Test
+    @SpecAssertions({ @SpecAssertion(section = BEANCONTAINER, id = "aa"),
+            @SpecAssertion(section = BEANCONTAINER, id = "ab"),
+            @SpecAssertion(section = BEANCONTAINER, id = "ac") })
+    public void testInjectionOfBeanContainerType() {
+        // bean injection; use the container for arbitrary action
+        myBean.getBeanContainer().isNormalScope(ApplicationScoped.class);
+
+        // dynamic resolution, verify type, explicit qualifier and test scope
+        Instance<BeanContainer> beanContainerInstance = instance.select(BeanContainer.class, Default.Literal.INSTANCE);
+        Assert.assertTrue(beanContainerInstance.isResolvable());
+        Assert.assertEquals(beanContainerInstance.getHandle().getBean().getScope(), Dependent.class);
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/injection/MyBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/injection/MyBean.java
@@ -1,0 +1,16 @@
+package org.jboss.cdi.tck.tests.beanContainer.injection;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.BeanContainer;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class MyBean {
+
+    @Inject
+    BeanContainer beanContainer;
+
+    public BeanContainer getBeanContainer() {
+        return beanContainer;
+    }
+}

--- a/impl/src/main/resources/tck-audit-cdi.xml
+++ b/impl/src/main/resources/tck-audit-cdi.xml
@@ -5882,6 +5882,24 @@
     </section>
 
     <!-- Core CDI/CDI Lite/Build compatible extensions -->
+    <section id="beancontainer" title="The BeanContainer object" level="2">
+        <group>
+            <text>The container provides a built-in bean with bean type |BeanContainer|, scope |@Dependent| and qualifier |@Default|.</text>
+
+            <assertion id="aa">
+                <text>Test the bean type.</text>
+            </assertion>
+
+            <assertion id="ab">
+                <text>Test the scope.</text>
+            </assertion>
+
+            <assertion id="ac">
+                <text>Test the qualifier.</text>
+            </assertion>
+        </group>
+    </section>
+
     <section id="build_spi" title="Build compatible extensions" level="2">
     </section>
 


### PR DESCRIPTION
Fixes #402 

Tests that `BeanContainer` can be simply injected but also verifies exact type, qualifier and scope of the bean.