### PR TITLE
Move test for BM passivation into CDI_FULL test group

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/BeanManagerTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/BeanManagerTest.java
@@ -21,6 +21,7 @@ import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static org.jboss.cdi.tck.TestGroups.CDI_FULL;
+import static org.jboss.cdi.tck.cdi.Sections.BEANMANAGER;
 import static org.jboss.cdi.tck.cdi.Sections.BM_DETERMINING_ANNOTATION;
 import static org.jboss.cdi.tck.cdi.Sections.BM_OBTAIN_ANNOTATEDTYPE;
 import static org.jboss.cdi.tck.cdi.Sections.BM_OBTAIN_ELRESOLVER;
@@ -55,6 +56,7 @@ import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
+import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -192,5 +194,15 @@ public class BeanManagerTest extends AbstractTest {
             return;
         }
         fail();
+    }
+
+    @Test
+    @SpecAssertion(section = BEANMANAGER, id = "b")
+    public void testManagerBeanIsPassivationCapable() {
+        assertTrue(isSerializable(getCurrentManager().getClass()));
+    }
+
+    private boolean isSerializable(Class<?> clazz) {
+        return clazz.isPrimitive() || Serializable.class.isAssignableFrom(clazz);
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/ManagerTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/ManagerTest.java
@@ -19,7 +19,6 @@ package org.jboss.cdi.tck.tests.lookup.manager;
 import static org.jboss.cdi.tck.cdi.Sections.BEANMANAGER;
 import static org.jboss.cdi.tck.cdi.Sections.BM_OBTAIN_CONTEXTUAL_REFERENCE;
 
-import java.io.Serializable;
 import java.math.BigDecimal;
 
 import jakarta.enterprise.context.Dependent;
@@ -72,12 +71,6 @@ public class ManagerTest extends AbstractTest {
     }
 
     @Test
-    @SpecAssertion(section = BEANMANAGER, id = "b")
-    public void testManagerBeanIsPassivationCapable() {
-        assert isSerializable(getCurrentManager().getClass());
-    }
-
-    @Test
     @SpecAssertions({ @SpecAssertion(section = BM_OBTAIN_CONTEXTUAL_REFERENCE, id = "a"), @SpecAssertion(section = BM_OBTAIN_CONTEXTUAL_REFERENCE, id = "b") })
     public void testGetReferenceReturnsContextualInstance() {
         Bean<FishFarmOffice> bean = getBeans(FishFarmOffice.class).iterator().next();
@@ -89,10 +82,6 @@ public class ManagerTest extends AbstractTest {
     public void testGetReferenceWithIllegalBeanType() {
         Bean<FishFarmOffice> bean = getBeans(FishFarmOffice.class).iterator().next();
         getCurrentManager().getReference(bean, BigDecimal.class, getCurrentManager().createCreationalContext(bean));
-    }
-
-    private boolean isSerializable(Class<?> clazz) {
-        return clazz.isPrimitive() || Serializable.class.isAssignableFrom(clazz);
     }
 
 }


### PR DESCRIPTION
Fixes #408 

Test functionality is exactly the same, only the group is changed (`BeanManagerTest` has `Test(groups = CDI_FULL)`) so that passivation tests are not part of Lite testsuite.