### PR TITLE
Remove superflous beans.xml, correct interceptor priority

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/CharlieInterceptor2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/CharlieInterceptor2.java
@@ -23,7 +23,7 @@ import jakarta.interceptor.InvocationContext;
 
 @Interceptor
 @CharlieBinding
-@Priority(1000)
+@Priority(1001)
 public class CharlieInterceptor2 extends AbstractInterceptor {
 
     @AroundConstruct

--- a/impl/src/main/resources/org/jboss/cdi/tck/tests/context/dependent/beans.xml
+++ b/impl/src/main/resources/org/jboss/cdi/tck/tests/context/dependent/beans.xml
@@ -1,7 +1,0 @@
-<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0" bean-discovery-mode="all">
-   <interceptors>
-      <class>org.jboss.cdi.tck.tests.context.dependent.TransactionalInterceptor</class>
-   </interceptors>
-</beans>


### PR DESCRIPTION
The removed `beans.xml` isn't needed as the test with corresponding package is no longer using it (removed as part of [this PR](https://github.com/jakartaee/cdi-tck/commit/021f446d5bceffc7169ec463671236c04aeb2022))

The other change is related to `impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/AroundConstructTest` where there is an assertion on ordering of interceptors - [see this](https://github.com/jakartaee/cdi-tck/blob/master/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/AroundConstructTest.java#L82-L93). Both related interceptors have equal priority (1000) which means undefined ordering. This wasn't discovered earlier because Weld (accidentally) orders them just as the test expects.

@jeanouii would you please mind taking a look at the aforementioned test and letting me know how/if that works for your impl?