### PR TITLE
Fix invalid annotation literals

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ConstructorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ConstructorBinding.java
@@ -25,6 +25,7 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.interceptor.InterceptorBinding;
 
 @Target({ TYPE, CONSTRUCTOR })
@@ -34,4 +35,6 @@ import jakarta.interceptor.InterceptorBinding;
 @Documented
 @InterceptorBinding
 public @interface ConstructorBinding {
+    class Literal extends AnnotationLiteral<ConstructorBinding> implements ConstructorBinding {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/CreativeBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/CreativeBinding.java
@@ -25,6 +25,7 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.interceptor.InterceptorBinding;
 
 @Target({ TYPE, CONSTRUCTOR })
@@ -33,4 +34,6 @@ import jakarta.interceptor.InterceptorBinding;
 @Documented
 @InterceptorBinding
 public @interface CreativeBinding {
+    class Literal extends AnnotationLiteral<CreativeBinding> implements CreativeBinding {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/InterceptorBindingResolutionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/InterceptorBindingResolutionTest.java
@@ -73,12 +73,12 @@ public class InterceptorBindingResolutionTest extends AbstractTest {
         // Test interceptor is resolved (note non-binding member of BallBinding)
         assertEquals(
                 getCurrentManager().resolveInterceptors(InterceptionType.AROUND_INVOKE,
-                        new AnnotationLiteral<MessageBinding>() {
-                        }, new AnnotationLiteral<LoggedBinding>() {
-                        }, new AnnotationLiteral<TransactionalBinding>() {
-                        }, new AnnotationLiteral<PingBinding>() {
-                        }, new AnnotationLiteral<PongBinding>() {
-                        }, new BallBindingLiteral(true, true)).size(), 1);
+                        new MessageBinding.Literal(),
+                        new LoggedBinding.Literal(),
+                        new TransactionalBinding.Literal(),
+                        new PingBinding.Literal(),
+                        new PongBinding.Literal(),
+                        new BallBindingLiteral(true, true)).size(), 1);
 
         // Test the set of interceptor bindings
         assertNotNull(messageService);
@@ -101,16 +101,16 @@ public class InterceptorBindingResolutionTest extends AbstractTest {
         // Test interceptor is resolved (note non-binding member of BallBinding)
         assertEquals(
                 getCurrentManager().resolveInterceptors(InterceptionType.POST_CONSTRUCT,
-                        new AnnotationLiteral<MessageBinding>() {
-                        }, new AnnotationLiteral<LoggedBinding>() {
-                        }, new AnnotationLiteral<TransactionalBinding>() {
-                        }, new BasketBindingLiteral(true, true)).size(), 1);
+                        new MessageBinding.Literal(),
+                        new LoggedBinding.Literal(),
+                        new TransactionalBinding.Literal(),
+                        new BasketBindingLiteral(true, true)).size(), 1);
         assertEquals(
                 getCurrentManager().resolveInterceptors(InterceptionType.PRE_DESTROY,
-                        new AnnotationLiteral<MessageBinding>() {
-                        }, new AnnotationLiteral<LoggedBinding>() {
-                        }, new AnnotationLiteral<TransactionalBinding>() {
-                        }, new BasketBindingLiteral(true, true)).size(), 1);
+                        new MessageBinding.Literal(),
+                        new LoggedBinding.Literal(),
+                        new TransactionalBinding.Literal(),
+                        new BasketBindingLiteral(true, true)).size(), 1);
 
         // Test the set of interceptor bindings
         ComplicatedLifecycleInterceptor.reset();
@@ -134,12 +134,11 @@ public class InterceptorBindingResolutionTest extends AbstractTest {
         // Test interceptor is resolved
         assertEquals(
                 getCurrentManager().resolveInterceptors(InterceptionType.AROUND_CONSTRUCT,
-                        new AnnotationLiteral<MachineBinding>() {
-                        }, new AnnotationLiteral<LoggedBinding>() {
-                        }, new AnnotationLiteral<TransactionalBinding>() {
-                        }, new AnnotationLiteral<ConstructorBinding>() {
-                        }, new AnnotationLiteral<CreativeBinding>() {
-                        }).size(), 1);
+                        new MachineBinding.Literal(),
+                        new LoggedBinding.Literal(),
+                        new TransactionalBinding.Literal(),
+                        new ConstructorBinding.Literal(),
+                        new CreativeBinding.Literal()).size(), 1);
 
         // Test the set of interceptor bindings
         ComplicatedAroundConstructInterceptor.reset();

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/LoggedBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/LoggedBinding.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.interceptor.InterceptorBinding;
 
 @Target({ TYPE })
@@ -32,4 +33,6 @@ import jakarta.interceptor.InterceptorBinding;
 @Documented
 @InterceptorBinding
 public @interface LoggedBinding {
+    class Literal extends AnnotationLiteral<LoggedBinding> implements LoggedBinding {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/MachineBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/MachineBinding.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.interceptor.InterceptorBinding;
 
 @Target(TYPE)
@@ -32,4 +33,6 @@ import jakarta.interceptor.InterceptorBinding;
 @Documented
 @InterceptorBinding
 public @interface MachineBinding {
+    class Literal extends AnnotationLiteral<MachineBinding> implements MachineBinding {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/MessageBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/MessageBinding.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.interceptor.InterceptorBinding;
 
 @Target({ TYPE })
@@ -32,4 +33,6 @@ import jakarta.interceptor.InterceptorBinding;
 @Documented
 @InterceptorBinding
 public @interface MessageBinding {
+    class Literal extends AnnotationLiteral<MessageBinding> implements MessageBinding {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/PingBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/PingBinding.java
@@ -25,6 +25,7 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.interceptor.InterceptorBinding;
 
 @Target({ TYPE, METHOD })
@@ -34,4 +35,6 @@ import jakarta.interceptor.InterceptorBinding;
 @Documented
 @InterceptorBinding
 public @interface PingBinding {
+    class Literal extends AnnotationLiteral<PingBinding> implements PingBinding {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/PongBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/PongBinding.java
@@ -25,6 +25,7 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.interceptor.InterceptorBinding;
 
 @Target({ TYPE, METHOD })
@@ -34,4 +35,6 @@ import jakarta.interceptor.InterceptorBinding;
 @Documented
 @InterceptorBinding
 public @interface PongBinding {
+    class Literal extends AnnotationLiteral<PongBinding> implements PongBinding {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/TransactionalBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/TransactionalBinding.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.interceptor.InterceptorBinding;
 
 @Target({ TYPE })
@@ -32,4 +33,6 @@ import jakarta.interceptor.InterceptorBinding;
 @Documented
 @InterceptorBinding
 public @interface TransactionalBinding {
+    class Literal extends AnnotationLiteral<TransactionalBinding> implements TransactionalBinding {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/literals/InheritedLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/literals/InheritedLiteral.java
@@ -1,0 +1,9 @@
+package org.jboss.cdi.tck.literals;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+
+import java.lang.annotation.Inherited;
+
+public class InheritedLiteral extends AnnotationLiteral<Inherited> implements Inherited {
+    public static InheritedLiteral INSTANCE = new InheritedLiteral();
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/literals/OverrideLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/literals/OverrideLiteral.java
@@ -1,0 +1,7 @@
+package org.jboss.cdi.tck.literals;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+
+public class OverrideLiteral extends AnnotationLiteral<Override> implements Override {
+    public static OverrideLiteral INSTANCE = new OverrideLiteral();
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/literals/StereotypeLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/literals/StereotypeLiteral.java
@@ -1,0 +1,8 @@
+package org.jboss.cdi.tck.literals;
+
+import jakarta.enterprise.inject.Stereotype;
+import jakarta.enterprise.util.AnnotationLiteral;
+
+public class StereotypeLiteral extends AnnotationLiteral<Stereotype> implements Stereotype {
+    public static StereotypeLiteral INSTANCE = new StereotypeLiteral();
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/DependentContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/DependentContextTest.java
@@ -51,10 +51,8 @@ import org.testng.annotations.Test;
 @SpecVersion(spec = "cdi", version = "2.0")
 public class DependentContextTest extends AbstractTest {
 
-    private static final Annotation TAME_LITERAL = new AnnotationLiteral<Tame>() {
-    };
-    private static final Annotation PET_LITERAL = new AnnotationLiteral<Pet>() {
-    };
+    private static final Annotation TAME_LITERAL = new Tame.Literal();
+    private static final Annotation PET_LITERAL = new Pet.Literal();
 
     @Deployment
     public static WebArchive createTestArchive() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/Pet.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/Pet.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Pet {
-
+    class Literal extends AnnotationLiteral<Pet> implements Pet {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/Tame.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Tame {
-
+    class Literal extends AnnotationLiteral<Tame> implements Tame {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/StereotypeDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/StereotypeDefinitionTest.java
@@ -44,8 +44,7 @@ import org.testng.annotations.Test;
 
 @SpecVersion(spec = "cdi", version = "2.0")
 public class StereotypeDefinitionTest extends AbstractTest {
-    private static final Annotation TAME_LITERAL = new AnnotationLiteral<Tame>() {
-    };
+    private static final Annotation TAME_LITERAL = new Tame.Literal();
 
     @Deployment
     public static WebArchive createTestArchive() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Tame.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Tame {
-
+    class Literal extends AnnotationLiteral<Tame> implements Tame {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/EventBindingTypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/EventBindingTypesTest.java
@@ -80,13 +80,13 @@ public class EventBindingTypesTest extends AbstractTest {
     @Test(expectedExceptions = { IllegalArgumentException.class })
     @SpecAssertion(section = EVENT_TYPES_AND_QUALIFIER_TYPES, id = "d")
     public void testFireEventWithNonRuntimeBindingTypeFails() {
-        getCurrentManager().getEvent().select(Animal.class, new AnnotationLiteral<NonRuntimeBindingType>() {}).fire(new Animal());
+        getCurrentManager().getEvent().select(Animal.class, new NonRuntimeBindingType.Literal()).fire(new Animal());
     }
 
     @Test(expectedExceptions = { IllegalArgumentException.class })
     @SpecAssertion(section = EVENT_TYPES_AND_QUALIFIER_TYPES, id = "g")
     public void testFireEventWithNonBindingAnnotationsFails() {
-        getCurrentManager().getEvent().select(Animal.class, new AnnotationLiteral<NonBindingType>() {}).fire(new Animal());
+        getCurrentManager().getEvent().select(Animal.class, new NonBindingType.Literal()).fire(new Animal());
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/NonBindingType.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/NonBindingType.java
@@ -16,6 +16,8 @@
  */
 package org.jboss.cdi.tck.tests.event.bindingTypes;
 
+import jakarta.enterprise.util.AnnotationLiteral;
+
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -26,4 +28,6 @@ import java.lang.annotation.Target;
 @Target({ FIELD, PARAMETER })
 @Retention(RUNTIME)
 public @interface NonBindingType {
+    class Literal extends AnnotationLiteral<NonBindingType> implements NonBindingType {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/NonRuntimeBindingType.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/NonRuntimeBindingType.java
@@ -23,10 +23,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ FIELD, PARAMETER })
 @Qualifier
 @Retention(RetentionPolicy.CLASS)
 public @interface NonRuntimeBindingType {
+    class Literal extends AnnotationLiteral<NonRuntimeBindingType> implements NonRuntimeBindingType {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/EventTypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/EventTypesTest.java
@@ -41,8 +41,7 @@ import org.testng.annotations.Test;
 @SpecVersion(spec = "cdi", version = "2.0")
 public class EventTypesTest extends AbstractTest {
 
-    private AnnotationLiteral<Extra> extraLiteral = new AnnotationLiteral<Extra>() {
-    };
+    private AnnotationLiteral<Extra> extraLiteral = new Extra.Literal();
 
     @Deployment
     public static WebArchive createTestArchive() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/Extra.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/Extra.java
@@ -10,6 +10,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -17,4 +18,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Extra {
+    class Literal extends AnnotationLiteral<Extra> implements Extra {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/MiniBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/MiniBar.java
@@ -82,8 +82,7 @@ public class MiniBar {
             throw new IllegalArgumentException("Item already restored");
         }
 
-        itemEvent.select(new AnnotationLiteral<Restored>() {
-        }).fire(item);
+        itemEvent.select(new Restored.Literal()).fire(item);
     }
 
     public void stock() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/Restored.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/Restored.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,4 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Restored {
+    class Literal extends AnnotationLiteral<Restored> implements Restored {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/Number.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/Number.java
@@ -10,6 +10,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -17,6 +18,7 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Number {
-
+    class Literal extends AnnotationLiteral<Number> implements Number {
+    }
 }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/ObserverMethodTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/ObserverMethodTest.java
@@ -135,8 +135,7 @@ public class ObserverMethodTest extends AbstractTest {
     @SpecAssertion(section = OBSERVER_METHOD, id = "f")
     public void testNotifyOnObserverMethod() {
         Integer event = Integer.valueOf(1);
-        Set<ObserverMethod<? super Integer>> observerMethods = getCurrentManager().resolveObserverMethods(event, new AnnotationLiteral<Number>() {
-        });
+        Set<ObserverMethod<? super Integer>> observerMethods = getCurrentManager().resolveObserverMethods(event, new Number.Literal());
         assertEquals(observerMethods.size(), 1);
         observerMethods.iterator().next().notify(event);
         assertTrue(IntegerObserver.wasNotified);

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/ResolveEventObserversTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/ResolveEventObserversTest.java
@@ -36,10 +36,10 @@ import java.util.Set;
 
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.spi.ObserverMethod;
-import jakarta.enterprise.util.AnnotationLiteral;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.literals.OverrideLiteral;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
@@ -120,15 +120,13 @@ public class ResolveEventObserversTest extends AbstractTest {
     @Test(expectedExceptions = { IllegalArgumentException.class })
     @SpecAssertion(section = BM_OBSERVER_METHOD_RESOLUTION, id = "e")
     public void testBeanManagerResolveObserversWithIllegalQualifier() {
-        getCurrentManager().resolveObserverMethods(new SimpleEventType(), new AnnotationLiteral<Override>() {
-        });
+        getCurrentManager().resolveObserverMethods(new SimpleEventType(), OverrideLiteral.INSTANCE);
     }
 
     @Test
     @SpecAssertion(section = BEAN_DISCOVERY_STEPS, id = "o")
     public void testObserverMethodAutomaticallyRegistered() {
-        assertFalse(getCurrentManager().resolveObserverMethods(new String(), new AnnotationLiteral<Secret>() {
-        }).isEmpty());
+        assertFalse(getCurrentManager().resolveObserverMethods(new String(), new Secret.Literal()).isEmpty());
     }
 
     @Test
@@ -138,8 +136,7 @@ public class ResolveEventObserversTest extends AbstractTest {
         assertEquals(ghostObservers.size(), 0);
 
         Set<ObserverMethod<? super String>> stringObservers = getCurrentManager().resolveObserverMethods(new String(),
-                new AnnotationLiteral<Secret>() {
-                });
+                new Secret.Literal());
         assertEquals(stringObservers.size(), 1);
         for (ObserverMethod<? super String> observer : stringObservers) {
             // an assertion error will be raised if an inappropriate observer is called

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/Secret.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/Secret.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,4 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Secret {
+    class Literal extends AnnotationLiteral<Secret> implements Secret {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/select/NotABindingType.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/select/NotABindingType.java
@@ -16,6 +16,8 @@
  */
 package org.jboss.cdi.tck.tests.event.select;
 
+import jakarta.enterprise.util.AnnotationLiteral;
+
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
@@ -30,4 +32,6 @@ import java.lang.annotation.Target;
 @Retention(RUNTIME)
 @Documented
 public @interface NotABindingType {
+    class Literal extends AnnotationLiteral<NotABindingType> implements NotABindingType {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/select/SelectEventTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/select/SelectEventTest.java
@@ -69,8 +69,7 @@ public class SelectEventTest extends AbstractTest {
         assert alarm.getNumBreakIns() == 1;
         assert alarm.getNumViolentBreakIns() == 0;
 
-        sensor.securityEvent.select(BreakInEvent.class, new AnnotationLiteral<Violent>() {
-        }).fire(new BreakInEvent());
+        sensor.securityEvent.select(BreakInEvent.class, new Violent.Literal()).fire(new BreakInEvent());
         assert alarm.getNumSecurityEvents() == 4;
         assert alarm.getNumSystemTests() == 1;
         assert alarm.getNumBreakIns() == 2;
@@ -107,15 +106,13 @@ public class SelectEventTest extends AbstractTest {
     @SpecAssertion(section = EVENT, id = "ec")
     public void testEventSelectThrowsExceptionIfAnnotationIsNotBindingType() {
         SecuritySensor sensor = getContextualReference(SecuritySensor.class);
-        sensor.securityEvent.select(new AnnotationLiteral<NotABindingType>() {
-        });
+        sensor.securityEvent.select(new NotABindingType.Literal());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     @SpecAssertion(section = EVENT, id = "ec")
     public void testEventSelectWithSubtypeThrowsExceptionIfAnnotationIsNotBindingType() {
         SecuritySensor sensor = getContextualReference(SecuritySensor.class);
-        sensor.securityEvent.select(BreakInEvent.class, new AnnotationLiteral<NotABindingType>() {
-        });
+        sensor.securityEvent.select(BreakInEvent.class, new NotABindingType.Literal());
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/select/Violent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/select/Violent.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,4 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Violent {
+    class Literal extends AnnotationLiteral<Violent> implements Violent {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/AlternativeAvailabilityTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/AlternativeAvailabilityTest.java
@@ -59,12 +59,10 @@ public class AlternativeAvailabilityTest extends AbstractTest {
     }
 
     @SuppressWarnings("serial")
-    private static final AnnotationLiteral<Wild> WILD_LITERAL = new AnnotationLiteral<Wild>() {
-    };
+    private static final AnnotationLiteral<Wild> WILD_LITERAL = new Wild.Literal();
 
     @SuppressWarnings("serial")
-    private static final AnnotationLiteral<Tame> TAME_LITERAL = new AnnotationLiteral<Tame>() {
-    };
+    private static final AnnotationLiteral<Tame> TAME_LITERAL = new Tame.Literal();
 
     @Test
     @SpecAssertion(section = SELECTION, id = "e")

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Tame.java
@@ -22,6 +22,7 @@ import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 import java.lang.annotation.Retention;
@@ -31,5 +32,6 @@ import java.lang.annotation.Target;
 @Retention(RUNTIME)
 @Qualifier
 public @interface Tame {
-
+    class Literal extends AnnotationLiteral<Tame> implements Tame {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Wild.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Wild.java
@@ -22,6 +22,7 @@ import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 import java.lang.annotation.Retention;
@@ -31,5 +32,6 @@ import java.lang.annotation.Target;
 @Retention(RUNTIME)
 @Qualifier
 public @interface Wild {
-
+    class Literal extends AnnotationLiteral<Wild> implements Wild {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/DecoratorDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/DecoratorDefinitionTest.java
@@ -155,24 +155,21 @@ public class DecoratorDefinitionTest extends AbstractTest {
     @Test(expectedExceptions = IllegalArgumentException.class)
     @SpecAssertion(section = BM_DECORATOR_RESOLUTION, id = "c")
     public void testDuplicateBindingsOnResolveDecoratorsFails() {
-        Annotation binding = new AnnotationLiteral<Meta>() {
-        };
+        Annotation binding = new Meta.Literal();
         getCurrentManager().resolveDecorators(FooBar.TYPES, binding, binding);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     @SpecAssertion(section = BM_DECORATOR_RESOLUTION, id = "d")
     public void testNonBindingsOnResolveDecoratorsFails() {
-        Annotation binding = new AnnotationLiteral<NonMeta>() {
-        };
+        Annotation binding = new NonMeta.Literal();
         getCurrentManager().resolveDecorators(FooBar.TYPES, binding);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     @SpecAssertion(section = BM_DECORATOR_RESOLUTION, id = "e")
     public void testEmptyTypeSetOnResolveDecoratorsFails() {
-        Annotation binding = new AnnotationLiteral<NonMeta>() {
-        };
+        Annotation binding = new NonMeta.Literal();
         getCurrentManager().resolveDecorators(new HashSet<Type>(), binding);
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/Meta.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/Meta.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Meta {
-
+    class Literal extends AnnotationLiteral<Meta> implements Meta {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/NonMeta.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/NonMeta.java
@@ -16,6 +16,8 @@
  */
 package org.jboss.cdi.tck.tests.full.decorators.definition;
 
+import jakarta.enterprise.util.AnnotationLiteral;
+
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
@@ -30,5 +32,6 @@ import java.lang.annotation.Target;
 @Retention(RUNTIME)
 @Documented
 public @interface NonMeta {
-
+    class Literal extends AnnotationLiteral<NonMeta> implements NonMeta {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/AlternativeMetadataTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/AlternativeMetadataTest.java
@@ -318,10 +318,8 @@ public class AlternativeMetadataTest extends AbstractTest {
     public void testContainerUsesOperationsOfAnnotatedNotReflectionApi() {
         assertEquals(getBeans(Sausage.class, Any.Literal.INSTANCE).size(), 1);
         // Overriding annotated type has no methods and fields and thus there are no cheap and expensive sausages
-        assertTrue(getBeans(Sausage.class, new AnnotationLiteral<Expensive>() {
-        }).isEmpty());
-        assertTrue(getBeans(Sausage.class, new AnnotationLiteral<Cheap>() {
-        }).isEmpty());
+        assertTrue(getBeans(Sausage.class, new Expensive.Literal()).isEmpty());
+        assertTrue(getBeans(Sausage.class, new Cheap.Literal()).isEmpty());
     }
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Cheap.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Cheap.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Cheap {
-
+    class Literal extends AnnotationLiteral<Cheap> implements Cheap {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Expensive.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Expensive.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Expensive {
-
+    class Literal extends AnnotationLiteral<Expensive> implements Expensive {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/GroceryInterceptorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/GroceryInterceptorBinding.java
@@ -23,11 +23,13 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.interceptor.InterceptorBinding;
 
 @InterceptorBinding
 @Target({ TYPE, METHOD })
 @Retention(RUNTIME)
 public @interface GroceryInterceptorBinding {
-
+    class Literal extends AnnotationLiteral<GroceryInterceptorBinding> implements GroceryInterceptorBinding {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/GroceryWrapper.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/GroceryWrapper.java
@@ -36,6 +36,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import org.jboss.cdi.tck.literals.ProducesLiteral;
 import org.jboss.cdi.tck.util.annotated.AnnotatedConstructorWrapper;
 import org.jboss.cdi.tck.util.annotated.AnnotatedFieldWrapper;
 import org.jboss.cdi.tck.util.annotated.AnnotatedMethodWrapper;
@@ -53,9 +55,8 @@ public class GroceryWrapper extends AnnotatedTypeWrapper<Grocery> {
     private static boolean getTypeClosureOfProducerMethodUsed = false;
 
     public GroceryWrapper(AnnotatedType<Grocery> delegate) {
-        super(delegate, false, RequestScoped.Literal.INSTANCE, new CheapLiteral(), new AnnotationLiteral<NamedStereotype>() {
-        }, new AnnotationLiteral<GroceryInterceptorBinding>() {
-        });
+        super(delegate, false, RequestScoped.Literal.INSTANCE, new CheapLiteral(), new NamedStereotype.Literal(),
+                new GroceryInterceptorBinding.Literal());
         typeClosure.add(Grocery.class);
         typeClosure.add(Object.class);
     }
@@ -91,8 +92,7 @@ public class GroceryWrapper extends AnnotatedTypeWrapper<Grocery> {
             } else if (field.getJavaMember().getName().equals("fruit")) {
                 fields.add(wrapFruitField(field, this, new CheapLiteral()));
             } else if (field.getBaseType().equals(Bread.class)) {
-                fields.add(wrapField(field, this, new AnnotationLiteral<Produces>() {
-                }));
+                fields.add(wrapField(field, this, ProducesLiteral.INSTANCE));
             } else {
                 fields.add(new AnnotatedFieldWrapper(field, this, true));
             }
@@ -108,14 +108,12 @@ public class GroceryWrapper extends AnnotatedTypeWrapper<Grocery> {
             if (method.getJavaMember().getName().equals("getMilk")) {
 
                 AnnotatedMethodWrapper<? super Grocery> wrappedMethod = new AnnotatedMethodWrapper(method, this, false,
-                        new AnnotationLiteral<Produces>() {
-                        });
+                        ProducesLiteral.INSTANCE);
                 methods.add(wrappedMethod);
             } else if (method.getJavaMember().getName().equals("getYogurt")) {
                 // wrap the method and its parameters
                 AnnotatedMethodWrapper<? super Grocery> wrappedMethod = new AnnotatedMethodWrapper(method, this, false, new ExpensiveLiteral(),
-                        new AnnotationLiteral<Produces>() {
-                        });
+                        ProducesLiteral.INSTANCE);
                 methods.add(wrapMethodParameters(method.getParameters(), wrappedMethod, false, new CheapLiteral()));
             } else if (method.getJavaMember().getName().equals("nonInjectAnnotatedInitializer")) {
                 AnnotatedMethodWrapper<? super Grocery> wrappedMethod = new AnnotatedMethodWrapper(method, this, true,

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/NamedStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/NamedStereotype.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import jakarta.enterprise.inject.Stereotype;
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Named;
 
 @Target(TYPE)
@@ -30,5 +31,6 @@ import jakarta.inject.Named;
 @Stereotype
 @Named
 public @interface NamedStereotype {
-
+    class Literal extends AnnotationLiteral<NamedStereotype> implements NamedStereotype {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/interceptor/AlternativeMetadataInterceptorInjectionTargetTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/interceptor/AlternativeMetadataInterceptorInjectionTargetTest.java
@@ -67,11 +67,9 @@ public class AlternativeMetadataInterceptorInjectionTargetTest extends AbstractT
         final AnnotatedType<Login> interceptedLogin = manager.createAnnotatedType(Login.class);
         AnnotatedType<Login> modifiedInterceptedLogin = new ForwardingAnnotatedType<Login>() {
             @SuppressWarnings("serial")
-            private final AnnotationLiteral<LoginInterceptorBinding> interceptorBinding = new AnnotationLiteral<LoginInterceptorBinding>() {
-            };
+            private final AnnotationLiteral<LoginInterceptorBinding> interceptorBinding = new LoginInterceptorBinding.Literal();
             @SuppressWarnings("serial")
-            private final AnnotationLiteral<Secured> securedAnnotation = new AnnotationLiteral<Secured>() {
-            };
+            private final AnnotationLiteral<Secured> securedAnnotation = new Secured.Literal();
 
             @Override
             public AnnotatedType<Login> delegate() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/interceptor/InterceptorExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/interceptor/InterceptorExtension.java
@@ -36,11 +36,9 @@ public class InterceptorExtension implements Extension {
         final AnnotatedType<Login> interceptedLogin = manager.createAnnotatedType(Login.class);
         AnnotatedType<Login> modifiedInterceptedLogin = new ForwardingAnnotatedType<Login>() {
             @SuppressWarnings("serial")
-            private final AnnotationLiteral<LoginInterceptorBinding> interceptorBinding = new AnnotationLiteral<LoginInterceptorBinding>() {
-            };
+            private final AnnotationLiteral<LoginInterceptorBinding> interceptorBinding = new LoginInterceptorBinding.Literal();
             @SuppressWarnings("serial")
-            private final AnnotationLiteral<Secured> securedAnnotation = new AnnotationLiteral<Secured>() {
-            };
+            private final AnnotationLiteral<Secured> securedAnnotation = new Secured.Literal();
 
             @Override
             public AnnotatedType<Login> delegate() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/interceptor/LoginInterceptorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/interceptor/LoginInterceptorBinding.java
@@ -23,11 +23,13 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.interceptor.InterceptorBinding;
 
 @InterceptorBinding
 @Target({ TYPE, METHOD })
 @Retention(RUNTIME)
 public @interface LoginInterceptorBinding {
-
+    class Literal extends AnnotationLiteral<LoginInterceptorBinding> implements LoginInterceptorBinding {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/interceptor/Secured.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/interceptor/Secured.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 
@@ -34,5 +35,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Secured {
-
+    class Literal extends AnnotationLiteral<Secured> implements Secured {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/BeanManagerTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/BeanManagerTest.java
@@ -46,7 +46,9 @@ import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.interceptor.InterceptorBinding;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.literals.InheritedLiteral;
 import org.jboss.cdi.tck.literals.RetentionLiteral;
+import org.jboss.cdi.tck.literals.StereotypeLiteral;
 import org.jboss.cdi.tck.literals.TargetLiteral;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.cdi.tck.tests.beanContainer.BeanContainerTest;
@@ -101,11 +103,9 @@ public class BeanManagerTest extends AbstractTest {
     public void testGetMetaAnnotationsForStereotype() {
         Set<Annotation> stereotypeAnnotations = getCurrentManager().getStereotypeDefinition(AnimalStereotype.class);
         assertEquals(stereotypeAnnotations.size(), 5);
-        assertTrue(stereotypeAnnotations.contains(new AnnotationLiteral<Stereotype>() {
-        }));
+        assertTrue(stereotypeAnnotations.contains(StereotypeLiteral.INSTANCE));
         assertTrue(stereotypeAnnotations.contains(RequestScoped.Literal.INSTANCE));
-        assertTrue(stereotypeAnnotations.contains(new AnnotationLiteral<Inherited>() {
-        }));
+        assertTrue(stereotypeAnnotations.contains(InheritedLiteral.INSTANCE));
         assertTrue(stereotypeAnnotations.contains(new RetentionLiteral() {
 
             public RetentionPolicy value() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bootstrap/unavailable/methods/Transactional.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bootstrap/unavailable/methods/Transactional.java
@@ -5,6 +5,7 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.interceptor.InterceptorBinding;
 
 import static java.lang.annotation.ElementType.METHOD;
@@ -17,5 +18,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Documented
 public @interface Transactional {
-
+    class Literal extends AnnotationLiteral<Transactional> implements Transactional {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bootstrap/unavailable/methods/WrongExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bootstrap/unavailable/methods/WrongExtension.java
@@ -121,8 +121,7 @@ public class WrongExtension implements Extension {
 
         new Invocation() {
             void execute() {
-                beanManager.resolveInterceptors(InterceptionType.AROUND_INVOKE, new AnnotationLiteral<Transactional>() {
-                });
+                beanManager.resolveInterceptors(InterceptionType.AROUND_INVOKE, new Transactional.Literal());
             }
         }.run();
 
@@ -178,8 +177,7 @@ public class WrongExtension implements Extension {
         beanManager.getBeans(Foo.class);
         beanManager.resolve(null);
         beanManager.resolveObserverMethods(new Foo());
-        beanManager.resolveInterceptors(InterceptionType.AROUND_INVOKE, new AnnotationLiteral<Transactional>() {
-        });
+        beanManager.resolveInterceptors(InterceptionType.AROUND_INVOKE, new Transactional.Literal());
         beanManager.resolveDecorators(new HashSet<Type>(Arrays.asList(Foo.class)));
         beanManager.validate(injectionPoint);
         beanManager.getPassivationCapableBean("foo");

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/communication/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/communication/Baz.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Baz {
-
+    class Literal extends AnnotationLiteral<Baz> implements Baz {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/communication/ExtensionBeta.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/communication/ExtensionBeta.java
@@ -34,7 +34,7 @@ public class ExtensionBeta implements Extension {
     @SuppressWarnings("serial")
     public void observeProcessAnnotatedType(@Observes ProcessBean<?> event, BeanManager beanManager) {
         if (event.getBean().getBeanClass().equals(Foo.class) || event.getBean().getBeanClass().equals(Bar.class)) {
-            beanManager.getEvent().select(PbEvent.class, new AnnotationLiteral<Baz>() {}).fire(new PbEvent(event.getBean().getBeanClass()));
+            beanManager.getEvent().select(PbEvent.class, new Baz.Literal()).fire(new PbEvent(event.getBean().getBeanClass()));
         }
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/AfterTypeDiscoveryTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/AfterTypeDiscoveryTest.java
@@ -181,12 +181,10 @@ public class AfterTypeDiscoveryTest extends AbstractTest {
         getUniqueBean(Boss.class);
 
         assertEquals(getBeans(Bar.class).size(), 0);
-        assertEquals(getBeans(Bar.class, new AnnotationLiteral<Pro>() {
-        }).size(), 1);
+        assertEquals(getBeans(Bar.class, Pro.ProLiteral.INSTANCE).size(), 1);
 
         assertEquals(getBeans(Foo.class).size(), 0);
-        assertEquals(getBeans(Foo.class, new AnnotationLiteral<Pro>() {
-        }).size(), 1);
+        assertEquals(getBeans(Foo.class, Pro.ProLiteral.INSTANCE).size(), 1);
     }
 
     @SuppressWarnings("serial")

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/BeforeBeanDiscoveryObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/BeforeBeanDiscoveryObserver.java
@@ -82,8 +82,7 @@ public class BeforeBeanDiscoveryObserver implements Extension {
                 for (final AnnotatedMethod<? super Skill> method : super.getMethods()) {
                     if ("level".equals(method.getJavaMember().getName())) {
                         methods.add(new AnnotatedMethodWrapper<Skill>((AnnotatedMethod<Skill>) method, this, true,
-                                new AnnotationLiteral<Nonbinding>() {
-                                }));
+                                new Nonbinding.Literal()));
                     } else {
                         methods.add(new AnnotatedMethodWrapper<Skill>((AnnotatedMethod<Skill>) method, this, true));
                     }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/BeforeBeanDiscoveryTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/BeforeBeanDiscoveryTest.java
@@ -85,8 +85,7 @@ public class BeforeBeanDiscoveryTest extends AbstractTest {
     public void testAddingQualifierByClass() {
         assertTrue(BeforeBeanDiscoveryObserver.isObserved());
         assertEquals(getBeans(Alligator.class).size(), 0);
-        assertEquals(getBeans(Alligator.class, new AnnotationLiteral<Tame>() {
-        }).size(), 1);
+        assertEquals(getBeans(Alligator.class, new Tame.Literal()).size(), 1);
         assertTrue(getCurrentManager().isQualifier(Tame.class));
     }
 
@@ -129,11 +128,9 @@ public class BeforeBeanDiscoveryTest extends AbstractTest {
     public void testAddAnnotatedType() {
         getUniqueBean(Boss.class);
         assertEquals(getBeans(Bar.class).size(), 0);
-        assertEquals(getBeans(Bar.class, new AnnotationLiteral<Pro>() {
-        }).size(), 1);
+        assertEquals(getBeans(Bar.class, Pro.ProLiteral.INSTANCE).size(), 1);
         assertEquals(getBeans(Foo.class).size(), 0);
-        assertEquals(getBeans(Foo.class, new AnnotationLiteral<Pro>() {
-        }).size(), 1);
+        assertEquals(getBeans(Foo.class, Pro.ProLiteral.INSTANCE).size(), 1);
     }
 
     @SuppressWarnings("serial")

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/Tame.java
@@ -16,6 +16,8 @@
  */
 package org.jboss.cdi.tck.tests.full.extensions.lifecycle.bbd;
 
+import jakarta.enterprise.util.AnnotationLiteral;
+
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
@@ -30,5 +32,6 @@ import java.lang.annotation.Target;
 @Retention(RUNTIME)
 @Documented
 public @interface Tame {
-
+    class Literal extends AnnotationLiteral<Tame> implements Tame {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/Noisy.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/Noisy.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Noisy {
-
+    class Literal extends AnnotationLiteral<Noisy> implements Noisy {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/ProducerTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/ProducerTest.java
@@ -141,8 +141,7 @@ public class ProducerTest extends AbstractTest {
             @SpecAssertion(section = PROCESS_PRODUCER, id = "da"), @SpecAssertion(section = BEAN_DISCOVERY_STEPS, id = "jb") })
     public void testProduceCallsProducerMethod() {
         Producer<Dog> producer = ProducerProcessor.getNoisyDogProducer();
-        Bean<Dog> dogBean = getUniqueBean(Dog.class, new AnnotationLiteral<Noisy>() {
-        });
+        Bean<Dog> dogBean = getUniqueBean(Dog.class, new Noisy.Literal());
         DogProducer.reset();
         Dog dog = producer.produce(getCurrentManager().createCreationalContext(dogBean));
         assert DogProducer.isNoisyDogProducerCalled();
@@ -153,8 +152,7 @@ public class ProducerTest extends AbstractTest {
     @SpecAssertions({ @SpecAssertion(section = PROCESS_PRODUCER, id = "e"), @SpecAssertion(section = PROCESS_PRODUCER, id = "ga") })
     public void testSetProducerOverridesProducer() {
         ProducerProcessor.reset();
-        assert getContextualReference(Cow.class, new AnnotationLiteral<Noisy>() {
-        }) instanceof Cow;
+        assert getContextualReference(Cow.class, new Noisy.Literal()) instanceof Cow;
         assert ProducerProcessor.isOverriddenCowProducerCalled();
     }
 
@@ -164,8 +162,7 @@ public class ProducerTest extends AbstractTest {
             @SpecAssertion(section = PROCESS_PRODUCER, id = "db"), @SpecAssertion(section = BEAN_DISCOVERY_STEPS, id = "jb") })
     public void testProduceAccessesProducerField() {
         Producer<Dog> producer = ProducerProcessor.getQuietDogProducer();
-        Bean<Dog> dogBean = getUniqueBean(Dog.class, new AnnotationLiteral<Quiet>() {
-        });
+        Bean<Dog> dogBean = getUniqueBean(Dog.class, new Quiet.Literal());
         DogProducer.reset();
         Dog dog = producer.produce(getCurrentManager().createCreationalContext(dogBean));
         assert dog.getColor().equals(DogProducer.QUIET_DOG_COLOR);
@@ -175,8 +172,7 @@ public class ProducerTest extends AbstractTest {
     @SpecAssertions({ @SpecAssertion(section = INJECTIONTARGET, id = "faa") })
     public void testProducerForMethodDisposesProduct() {
 
-        Bean<Dog> dogBean = getUniqueBean(Dog.class, new AnnotationLiteral<Noisy>() {
-        });
+        Bean<Dog> dogBean = getUniqueBean(Dog.class, new Noisy.Literal());
         Producer<Dog> producer = ProducerProcessor.getNoisyDogProducer();
         DogProducer.reset();
         Dog dog = producer.produce(getCurrentManager().createCreationalContext(dogBean));
@@ -212,8 +208,7 @@ public class ProducerTest extends AbstractTest {
     @SpecAssertions({ @SpecAssertion(section = INJECTIONTARGET, id = "j"), @SpecAssertion(section = INJECTIONTARGET_EE, id = "b") })
     public void testInjectionTargetPostConstruct() {
         InjectionTarget<Dog> injectionTarget = ProducerProcessor.getDogInjectionTarget();
-        Dog dog = getContextualReference(Dog.class, new AnnotationLiteral<Noisy>() {
-        });
+        Dog dog = getContextualReference(Dog.class, new Noisy.Literal());
         Dog.setPostConstructCalled(false);
         injectionTarget.postConstruct(dog);
         assert Dog.isPostConstructCalled();
@@ -223,8 +218,7 @@ public class ProducerTest extends AbstractTest {
     @SpecAssertions({ @SpecAssertion(section = INJECTIONTARGET, id = "k"),  @SpecAssertion(section = INJECTIONTARGET_EE, id = "c") })
     public void testInjectionTargetPreDestroy() {
         InjectionTarget<Dog> injectionTarget = ProducerProcessor.getDogInjectionTarget();
-        Dog dog = getContextualReference(Dog.class, new AnnotationLiteral<Noisy>() {
-        });
+        Dog dog = getContextualReference(Dog.class, new Noisy.Literal());
         Dog.setPreDestroyCalled(false);
         injectionTarget.preDestroy(dog);
         assert Dog.isPreDestroyCalled();

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/Quiet.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/Quiet.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Quiet {
-
+    class Literal extends AnnotationLiteral<Quiet> implements Quiet {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/definition/ProducerMethodDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/definition/ProducerMethodDefinitionTest.java
@@ -29,9 +29,7 @@ public class ProducerMethodDefinitionTest extends AbstractTest {
     @Test(expectedExceptions = UnsatisfiedResolutionException.class)
     @SpecAssertions({ @SpecAssertion(section = MEMBER_LEVEL_INHERITANCE, id = "da"), @SpecAssertion(section = SPECIALIZATION, id = "cb") })
     public void testNonStaticProducerMethodNotInheritedBySpecializingSubclass() {
-        assertEquals(getBeans(Egg.class, new AnnotationLiteral<Yummy>() {
-        }).size(), 0);
-        getContextualReference(Egg.class, new AnnotationLiteral<Yummy>() {
-        });
+        assertEquals(getBeans(Egg.class, new Yummy.Literal()).size(), 0);
+        getContextualReference(Egg.class, new Yummy.Literal());
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/definition/Yummy.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/definition/Yummy.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Yummy {
-
+    class Literal extends AnnotationLiteral<Yummy> implements Yummy {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/Pet.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/Pet.java
@@ -22,6 +22,7 @@ import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 import java.lang.annotation.Documented;
@@ -33,5 +34,6 @@ import java.lang.annotation.Target;
 @Documented
 @Qualifier
 public @interface Pet {
-
+    class Literal extends AnnotationLiteral<Pet> implements Pet {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/ProducerMethodLifecycleTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/ProducerMethodLifecycleTest.java
@@ -20,8 +20,7 @@ import org.testng.annotations.Test;
 @Test(groups = CDI_FULL)
 public class ProducerMethodLifecycleTest extends AbstractTest {
 
-    private AnnotationLiteral<Pet> PET_LITERAL = new AnnotationLiteral<Pet>() {
-    };
+    private AnnotationLiteral<Pet> PET_LITERAL = new Pet.Literal();
 
     @Deployment
     public static WebArchive createTestArchive() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/simple/lifecycle/SimpleBeanLifecycleTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/simple/lifecycle/SimpleBeanLifecycleTest.java
@@ -22,8 +22,7 @@ import java.lang.annotation.Annotation;
 @Test(groups = CDI_FULL)
 public class SimpleBeanLifecycleTest extends AbstractTest {
 
-    private static final Annotation TAME_LITERAL = new AnnotationLiteral<Tame>() {
-    };
+    private static final Annotation TAME_LITERAL = new Tame.Literal();
 
     @Deployment
     public static WebArchive createTestArchive() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/simple/lifecycle/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/simple/lifecycle/Tame.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Tame {
-
+    class Literal extends AnnotationLiteral<Tame> implements Tame {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/Expensive.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/Expensive.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Expensive {
-
+    class Literal extends AnnotationLiteral<Expensive> implements Expensive {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/ProducerMethodSpecializationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/ProducerMethodSpecializationTest.java
@@ -46,11 +46,9 @@ import org.testng.annotations.Test;
 public class ProducerMethodSpecializationTest extends AbstractTest {
 
     @SuppressWarnings("serial")
-    private static Annotation EXPENSIVE_LITERAL = new AnnotationLiteral<Expensive>() {
-    };
+    private static Annotation EXPENSIVE_LITERAL = new Expensive.Literal();
     @SuppressWarnings("serial")
-    private static Annotation SPARKLY_LITERAL = new AnnotationLiteral<Sparkly>() {
-    };
+    private static Annotation SPARKLY_LITERAL = new Sparkly.Literal();
 
     @Deployment
     public static WebArchive createTestArchive() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/Sparkly.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/Sparkly.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Sparkly {
-
+    class Literal extends AnnotationLiteral<Sparkly> implements Sparkly {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/Landowner.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/Landowner.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Landowner {
-
+    class Literal extends AnnotationLiteral<Landowner> implements Landowner {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/Lazy.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/Lazy.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Lazy {
-
+    class Literal extends AnnotationLiteral<Lazy> implements Lazy {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/SimpleBeanSpecializationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/SimpleBeanSpecializationTest.java
@@ -48,12 +48,10 @@ import org.testng.annotations.Test;
 public class SimpleBeanSpecializationTest extends AbstractTest {
 
     @SuppressWarnings("serial")
-    private static Annotation LANDOWNER_LITERAL = new AnnotationLiteral<Landowner>() {
-    };
+    private static Annotation LANDOWNER_LITERAL = new Landowner.Literal();
 
     @SuppressWarnings("serial")
-    private static Annotation LAZY_LITERAL = new AnnotationLiteral<Lazy>() {
-    };
+    private static Annotation LAZY_LITERAL = new Lazy.Literal();
 
     @Deployment
     public static WebArchive createTestArchive() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/custom/CustomInterceptorImplementation.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/custom/CustomInterceptorImplementation.java
@@ -39,10 +39,8 @@ public class CustomInterceptorImplementation implements Interceptor<SimpleInterc
 
     public CustomInterceptorImplementation(InterceptionType type) {
         this.type = type;
-        interceptorBindingTypes.add(new AnnotationLiteral<Secure>() {
-        });
-        interceptorBindingTypes.add(new AnnotationLiteral<Transactional>() {
-        });
+        interceptorBindingTypes.add(new Secure.Literal());
+        interceptorBindingTypes.add(new Transactional.Literal());
     }
 
     public Set<InjectionPoint> getInjectionPoints() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/custom/Secure.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/custom/Secure.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.interceptor.InterceptorBinding;
 
 @Target({ TYPE, METHOD })
@@ -31,5 +32,6 @@ import jakarta.interceptor.InterceptorBinding;
 @Documented
 @InterceptorBinding
 public @interface Secure {
-
+    class Literal extends AnnotationLiteral<Secure> implements Secure {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/custom/Transactional.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/custom/Transactional.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.interceptor.InterceptorBinding;
 
 @Target({ TYPE, METHOD })
@@ -31,5 +32,6 @@ import jakarta.interceptor.InterceptorBinding;
 @Documented
 @InterceptorBinding
 public @interface Transactional {
-
+    class Literal extends AnnotationLiteral<Transactional> implements Transactional {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/VetoedTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/VetoedTest.java
@@ -94,8 +94,7 @@ public class VetoedTest extends AbstractTest {
         assertTrue(verifyingExtension.getClasses().contains(Shark.class));
         assertEquals(getCurrentManager().getBeans(Piranha.class, Any.Literal.INSTANCE).size(), 0);
         assertEquals(getCurrentManager().getBeans(Shark.class, Any.Literal.INSTANCE).size(), 1);
-        assertEquals(getCurrentManager().getBeans(Shark.class, new AnnotationLiteral<Fishy>() {
-        }).size(), 1);
+        assertEquals(getCurrentManager().getBeans(Shark.class, new Fishy.Literal()).size(), 1);
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/aquarium/Fishy.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/aquarium/Fishy.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Fishy {
-
+    class Literal extends AnnotationLiteral<Fishy> implements Fishy {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/Deadliest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/Deadliest.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Deadliest {
-
+    class Literal extends AnnotationLiteral<Deadliest> implements Deadliest {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/DisposalMethodDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/DisposalMethodDefinitionTest.java
@@ -49,12 +49,10 @@ import org.testng.annotations.Test;
 public class DisposalMethodDefinitionTest extends AbstractTest {
 
     @SuppressWarnings("serial")
-    private static final Annotation DEADLIEST_LITERAL = new AnnotationLiteral<Deadliest>() {
-    };
+    private static final Annotation DEADLIEST_LITERAL = new Deadliest.Literal();
 
     @SuppressWarnings("serial")
-    private static final Annotation TAME_LITERAL = new AnnotationLiteral<Tame>() {
-    };
+    private static final Annotation TAME_LITERAL = new Tame.Literal();
 
     @Deployment
     public static WebArchive createTestArchive() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/Tame.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Tame {
-
+    class Literal extends AnnotationLiteral<Tame> implements Tame {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/AsAnimal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/AsAnimal.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface AsAnimal {
-
+    class Literal extends AnnotationLiteral<AsAnimal> implements AsAnimal {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Foo.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Foo {
-
+    class Literal extends AnnotationLiteral<Foo> implements Foo {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Pet.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Pet.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Pet {
-
+    class Literal extends AnnotationLiteral<Pet> implements Pet {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/ProducerFieldDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/ProducerFieldDefinitionTest.java
@@ -58,14 +58,10 @@ import org.testng.annotations.Test;
 @SpecVersion(spec = "cdi", version = "2.0")
 public class ProducerFieldDefinitionTest extends AbstractTest {
 
-    private static final Annotation TAME_LITERAL = new AnnotationLiteral<Tame>() {
-    };
-    private static final Annotation PET_LITERAL = new AnnotationLiteral<Pet>() {
-    };
-    private static final Annotation FOO_LITERAL = new AnnotationLiteral<Foo>() {
-    };
-    private static final Annotation STATIC_LITERAL = new AnnotationLiteral<Static>() {
-    };
+    private static final Annotation TAME_LITERAL = new Tame.Literal();
+    private static final Annotation PET_LITERAL = new Pet.Literal();
+    private static final Annotation FOO_LITERAL = new Foo.Literal();
+    private static final Annotation STATIC_LITERAL = new Static.Literal();
 
     @Deployment
     public static WebArchive createTestArchive() {
@@ -117,8 +113,7 @@ public class ProducerFieldDefinitionTest extends AbstractTest {
    @Test
     @SpecAssertion(section = PRODUCER_FIELD_TYPES, id = "a")
     public void testApiTypeForInterfaceReturn() {
-        Set<Bean<Animal>> animalBeans = getBeans(Animal.class, new AnnotationLiteral<AsAnimal>() {
-        });
+        Set<Bean<Animal>> animalBeans = getBeans(Animal.class, new AsAnimal.Literal());
         assert animalBeans.size() == 1;
         Bean<Animal> animalModel = animalBeans.iterator().next();
         assert animalModel.getTypes().size() == 2;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Static.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Static.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Static {
-
+    class Literal extends AnnotationLiteral<Static> implements Static {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Tame.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Tame {
-
+    class Literal extends AnnotationLiteral<Tame> implements Tame {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/Broken.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Broken {
-
+    class Literal extends AnnotationLiteral<Broken> implements Broken {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/Null.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/Null.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Null {
-
+    class Literal extends AnnotationLiteral<Null> implements Null {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/ProducerFieldLifecycleTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/ProducerFieldLifecycleTest.java
@@ -40,14 +40,11 @@ import org.testng.annotations.Test;
 public class ProducerFieldLifecycleTest extends AbstractTest {
 
     @SuppressWarnings("serial")
-    private AnnotationLiteral<Null> NULL_LITERAL = new AnnotationLiteral<Null>() {
-    };
+    private AnnotationLiteral<Null> NULL_LITERAL = new Null.Literal();
     @SuppressWarnings("serial")
-    private AnnotationLiteral<Broken> BROKEN_LITERAL = new AnnotationLiteral<Broken>() {
-    };
+    private AnnotationLiteral<Broken> BROKEN_LITERAL = new Broken.Literal();
     @SuppressWarnings("serial")
-    private AnnotationLiteral<Tame> TAME_LITERAL = new AnnotationLiteral<Tame>() {
-    };
+    private AnnotationLiteral<Tame> TAME_LITERAL = new Tame.Literal();
 
     @Deployment
     public static WebArchive createTestArchive() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/Tame.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Tame {
-
+    class Literal extends AnnotationLiteral<Tame> implements Tame {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Deadliest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Deadliest.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Deadliest {
-
+    class Literal extends AnnotationLiteral<Deadliest> implements Deadliest {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Number.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Number.java
@@ -9,11 +9,13 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
 @Retention(RUNTIME)
 @Qualifier
 public @interface Number {
-
+    class Literal extends AnnotationLiteral<Number> implements Number {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/ProducerMethodDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/ProducerMethodDefinitionTest.java
@@ -64,14 +64,10 @@ import org.testng.annotations.Test;
 @SpecVersion(spec = "cdi", version = "2.0")
 public class ProducerMethodDefinitionTest extends AbstractTest {
 
-    private static final Annotation TAME_LITERAL = new AnnotationLiteral<Tame>() {
-    };
-    private static final Annotation DEADLIEST_LITERAL = new AnnotationLiteral<Deadliest>() {
-    };
-    private static final Annotation NUMBER_LITERAL = new AnnotationLiteral<Number>() {
-    };
-    private static final Annotation YUMMY_LITERAL = new AnnotationLiteral<Yummy>() {
-    };
+    private static final Annotation TAME_LITERAL = new Tame.Literal();
+    private static final Annotation DEADLIEST_LITERAL = new Deadliest.Literal();
+    private static final Annotation NUMBER_LITERAL = new Number.Literal();
+    private static final Annotation YUMMY_LITERAL = new Yummy.Literal();
 
     @Deployment
     public static WebArchive createTestArchive() {
@@ -233,10 +229,8 @@ public class ProducerMethodDefinitionTest extends AbstractTest {
     @Test
     @SpecAssertions({ @SpecAssertion(section = MEMBER_LEVEL_INHERITANCE, id = "da"), @SpecAssertion(section = MEMBER_LEVEL_INHERITANCE, id = "dg") })
     public void testNonStaticProducerMethodNotInherited() {
-        assertEquals(getBeans(Apple.class, new AnnotationLiteral<Yummy>() {
-        }).size(), 1);
-        assertEquals(getContextualReference(Apple.class, new AnnotationLiteral<Yummy>() {
-        }).getTree().getClass(), AppleTree.class);
+        assertEquals(getBeans(Apple.class, new Yummy.Literal()).size(), 1);
+        assertEquals(getContextualReference(Apple.class, new Yummy.Literal()).getTree().getClass(), AppleTree.class);
     }
 
     /**
@@ -265,8 +259,7 @@ public class ProducerMethodDefinitionTest extends AbstractTest {
     @Test(expectedExceptions = { IllegalProductException.class })
     @SpecAssertion(section = PRODUCER_METHOD, id = "f")
     public void testNonDependentProducerReturnsNullValue() {
-        getContextualReference(Pollen.class, new AnnotationLiteral<Yummy>() {
-        }).ping();
+        getContextualReference(Pollen.class, new Yummy.Literal()).ping();
         fail("IllegalProductException not thrown");
     }
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Tame.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Tame {
-
+    class Literal extends AnnotationLiteral<Tame> implements Tame {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Yummy.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Yummy.java
@@ -22,6 +22,7 @@ import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 import java.lang.annotation.Documented;
@@ -33,5 +34,6 @@ import java.lang.annotation.Target;
 @Documented
 @Qualifier
 public @interface Yummy {
-
+    class Literal extends AnnotationLiteral<Yummy> implements Yummy {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/name/Crazy.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/name/Crazy.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Crazy {
-
+    class Literal extends AnnotationLiteral<Crazy> implements Crazy {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/name/Funny.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/name/Funny.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Funny {
-
+    class Literal extends AnnotationLiteral<Funny> implements Funny {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/name/ProducerMethodWithDefaultNameTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/name/ProducerMethodWithDefaultNameTest.java
@@ -52,8 +52,7 @@ public class ProducerMethodWithDefaultNameTest extends AbstractTest {
     @SpecAssertion(section = PRODUCER_METHOD_NAME, id = "a")
     public void testMethodName() {
         String name = "findTerry";
-        Bean<Bug> terry = getUniqueBean(Bug.class, new AnnotationLiteral<Crazy>() {
-        });
+        Bean<Bug> terry = getUniqueBean(Bug.class, new Crazy.Literal());
         assertEquals(terry.getName(), name);
     }
 
@@ -69,8 +68,7 @@ public class ProducerMethodWithDefaultNameTest extends AbstractTest {
     @SpecAssertions({ @SpecAssertion(section = NAMED_STEREOTYPE, id = "aa"), @SpecAssertion(section = NAMED_STEREOTYPE, id = "ab") })
     public void testProducerMethodQualifiers() {
         String name = "produceJohn";
-        Bean<Bug> john = getUniqueBean(Bug.class, new AnnotationLiteral<Funny>() {
-        });
+        Bean<Bug> john = getUniqueBean(Bug.class, new Funny.Literal());
         assertEquals(john.getName(), name);
         assertTrue(annotationSetMatches(john.getQualifiers(), Any.Literal.INSTANCE, Default.Literal.INSTANCE));
     }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Fail.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Fail.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Fail {
-
+    class Literal extends AnnotationLiteral<Fail> implements Fail {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/FirstBorn.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/FirstBorn.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface FirstBorn {
-
+    class Literal extends AnnotationLiteral<FirstBorn> implements FirstBorn {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Null.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Null.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Null {
-
+    class Literal extends AnnotationLiteral<Null> implements Null {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Pet.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Pet.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Pet {
-
+    class Literal extends AnnotationLiteral<Pet> implements Pet {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/ProducerMethodLifecycleTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/ProducerMethodLifecycleTest.java
@@ -42,14 +42,10 @@ import org.testng.annotations.Test;
  */
 @SpecVersion(spec = "cdi", version = "2.0")
 public class ProducerMethodLifecycleTest extends AbstractTest {
-    private AnnotationLiteral<Pet> PET_LITERAL = new AnnotationLiteral<Pet>() {
-    };
-    private AnnotationLiteral<FirstBorn> FIRST_BORN_LITERAL = new AnnotationLiteral<FirstBorn>() {
-    };
-    private AnnotationLiteral<Fail> FAIL_LITERAL = new AnnotationLiteral<Fail>() {
-    };
-    private AnnotationLiteral<Null> NULL_LITERAL = new AnnotationLiteral<Null>() {
-    };
+    private AnnotationLiteral<Pet> PET_LITERAL = new Pet.Literal();
+    private AnnotationLiteral<FirstBorn> FIRST_BORN_LITERAL = new FirstBorn.Literal();
+    private AnnotationLiteral<Fail> FAIL_LITERAL = new Fail.Literal();
+    private AnnotationLiteral<Null> NULL_LITERAL = new Null.Literal();
 
     @Deployment
     public static WebArchive createTestArchive() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/Atomic.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/Atomic.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.interceptor.InterceptorBinding;
 
 @Target({ TYPE, METHOD })
@@ -32,5 +33,6 @@ import jakarta.interceptor.InterceptorBinding;
 @MissileBinding
 @InterceptorBinding
 public @interface Atomic {
-
+    class Literal extends AnnotationLiteral<Atomic> implements Atomic {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/InterceptorDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/InterceptorDefinitionTest.java
@@ -66,17 +66,13 @@ public class InterceptorDefinitionTest extends AbstractTest {
     private static final Transactional.TransactionalLiteral TRANSACTIONAL_LITERAL = new Transactional.TransactionalLiteral("") {
     };
 
-    private static final AnnotationLiteral<Secure> SECURE_LITERAL = new AnnotationLiteral<Secure>() {
-    };
+    private static final AnnotationLiteral<Secure> SECURE_LITERAL = new Secure.Literal();
 
-    private static final AnnotationLiteral<MissileBinding> MISSILE_LITERAL = new AnnotationLiteral<MissileBinding>() {
-    };
+    private static final AnnotationLiteral<MissileBinding> MISSILE_LITERAL = new MissileBinding.Literal();
 
-    private static final AnnotationLiteral<Logged> LOGGED_LITERAL = new AnnotationLiteral<Logged>() {
-    };
+    private static final AnnotationLiteral<Logged> LOGGED_LITERAL = new Logged.Literal();
 
-    private static final AnnotationLiteral<Atomic> ATOMIC_LITERAL = new AnnotationLiteral<Atomic>() {
-    };
+    private static final AnnotationLiteral<Atomic> ATOMIC_LITERAL = new Atomic.Literal();
 
     @Deployment
     public static WebArchive createTestArchive() {
@@ -177,8 +173,7 @@ public class InterceptorDefinitionTest extends AbstractTest {
     @Test(expectedExceptions = { IllegalArgumentException.class })
     @SpecAssertions({ @SpecAssertion(section = BM_INTERCEPTOR_RESOLUTION, id = "d") })
     public void testNonBindingTypeToResolveInterceptorsFails() {
-        Annotation nonBinding = new AnnotationLiteral<NonBindingType>() {
-        };
+        Annotation nonBinding = new NonBindingType.Literal();
         getCurrentManager().resolveInterceptors(InterceptionType.AROUND_INVOKE, nonBinding);
     }
 
@@ -233,8 +228,7 @@ public class InterceptorDefinitionTest extends AbstractTest {
     }
 
     private List<Interceptor<?>> getLoggedInterceptors() {
-        return getCurrentManager().resolveInterceptors(InterceptionType.AROUND_INVOKE, new AnnotationLiteral<Logged>() {
-        });
+        return getCurrentManager().resolveInterceptors(InterceptionType.AROUND_INVOKE, new Logged.Literal());
     }
 
     private Set<Type> getInterfacesImplemented(Class<?> clazz) {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/Logged.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/Logged.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.interceptor.InterceptorBinding;
 
 @Target({ TYPE, METHOD })
@@ -31,5 +32,6 @@ import jakarta.interceptor.InterceptorBinding;
 @Documented
 @InterceptorBinding
 public @interface Logged {
-
+    class Literal extends AnnotationLiteral<Logged> implements Logged {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/MissileBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/MissileBinding.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.interceptor.InterceptorBinding;
 
 @Target({ TYPE, METHOD })
@@ -31,5 +32,6 @@ import jakarta.interceptor.InterceptorBinding;
 @Documented
 @InterceptorBinding
 public @interface MissileBinding {
-
+    class Literal extends AnnotationLiteral<MissileBinding> implements MissileBinding {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/NonBindingType.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/NonBindingType.java
@@ -16,6 +16,8 @@
  */
 package org.jboss.cdi.tck.tests.interceptors.definition;
 
+import jakarta.enterprise.util.AnnotationLiteral;
+
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
@@ -30,5 +32,6 @@ import java.lang.annotation.Target;
 @Retention(RUNTIME)
 @Documented
 public @interface NonBindingType {
-
+    class Literal extends AnnotationLiteral<NonBindingType> implements NonBindingType {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/Secure.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/Secure.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.interceptor.InterceptorBinding;
 
 @Target({ TYPE, METHOD })
@@ -31,5 +32,6 @@ import jakarta.interceptor.InterceptorBinding;
 @Documented
 @InterceptorBinding
 public @interface Secure {
-
+    class Literal extends AnnotationLiteral<Secure> implements Secure {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/DynamicLookupTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/DynamicLookupTest.java
@@ -90,8 +90,7 @@ public class DynamicLookupTest extends AbstractTest {
     public void testNonBindingThrowsException() {
         try {
             ObtainsInstanceBean injectionPoint = getContextualReference(ObtainsInstanceBean.class);
-            injectionPoint.getAnyPaymentProcessor().select(new AnnotationLiteral<NonBinding>() {
-            });
+            injectionPoint.getAnyPaymentProcessor().select(new NonBinding.Literal());
         } catch (Throwable t) {
             assertTrue(isThrowablePresent(IllegalArgumentException.class, t));
             return;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/NonBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/NonBinding.java
@@ -16,6 +16,8 @@
  */
 package org.jboss.cdi.tck.tests.lookup.dynamic;
 
+import jakarta.enterprise.util.AnnotationLiteral;
+
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
@@ -30,5 +32,6 @@ import java.lang.annotation.Target;
 @Retention(RUNTIME)
 @Documented
 public @interface NonBinding {
-
+    class Literal extends AnnotationLiteral<NonBinding> implements NonBinding {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/builtin/BuiltinInstanceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/builtin/BuiltinInstanceTest.java
@@ -44,8 +44,7 @@ import org.testng.annotations.Test;
 public class BuiltinInstanceTest extends AbstractTest {
 
     @SuppressWarnings("serial")
-    private static final AnnotationLiteral<FarmBased> farmBasedLiteral = new AnnotationLiteral<FarmBased>() {
-    };
+    private static final AnnotationLiteral<FarmBased> farmBasedLiteral = new FarmBased.Literal();
 
     @Deployment
     public static WebArchive createTestArchive() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/builtin/FarmBased.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/builtin/FarmBased.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface FarmBased {
-
+    class Literal extends AnnotationLiteral<FarmBased> implements FarmBased {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/dynamic/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/dynamic/Bar.java
@@ -63,8 +63,7 @@ public class Bar {
 
     @SuppressWarnings("serial")
     public Foo getQualifierNiceFoo() {
-        return fooInstance.select(new AnnotationLiteral<Nice>() {
-        }).get();
+        return fooInstance.select(new Nice.Literal()).get();
     }
 
     public Foo getConstructorInjectionFoo() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/dynamic/DynamicInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/dynamic/DynamicInjectionPointTest.java
@@ -84,8 +84,7 @@ public class DynamicInjectionPointTest extends AbstractTest {
         Set<Annotation> niceFooQualifiers = bar.getQualifierNiceFoo().getInjectionPoint().getQualifiers();
 
         annotationSetMatches(fooQualifiers, Any.Literal.INSTANCE, Default.Literal.INSTANCE);
-        annotationSetMatches(niceFooQualifiers, Any.Literal.INSTANCE, new AnnotationLiteral<Nice>() {
-        });
+        annotationSetMatches(niceFooQualifiers, Any.Literal.INSTANCE, new Nice.Literal());
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/dynamic/Nice.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/dynamic/Nice.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Qualifier
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Retention(RUNTIME)
 @Documented
 public @interface Nice {
-
+    class Literal extends AnnotationLiteral<Nice> implements Nice {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Max.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Max.java
@@ -25,11 +25,13 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
 @Retention(RUNTIME)
 @Qualifier
 public @interface Max {
-
+    class Literal extends AnnotationLiteral<Max> implements Max {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Min.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Min.java
@@ -25,11 +25,13 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
 @Retention(RUNTIME)
 @Qualifier
 public @interface Min {
-
+    class Literal extends AnnotationLiteral<Min> implements Min {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Number.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Number.java
@@ -25,11 +25,13 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
 @Retention(RUNTIME)
 @Qualifier
 public @interface Number {
-
+    class Literal extends AnnotationLiteral<Number> implements Number {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/ResolutionByTypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/ResolutionByTypeTest.java
@@ -57,12 +57,9 @@ public class ResolutionByTypeTest extends AbstractTest {
     };
     private static final TypeLiteral<Cat<African>> AFRICAN_CAT = new TypeLiteral<Cat<African>>() {
     };
-    private static final Annotation TAME = new AnnotationLiteral<Tame>() {
-    };
-    private static final Annotation WILD = new AnnotationLiteral<Wild>() {
-    };
-    private static final Annotation NUMBER = new AnnotationLiteral<Number>() {
-    };
+    private static final Annotation TAME = new Tame.Literal();
+    private static final Annotation WILD = new Wild.Literal();
+    private static final Annotation NUMBER = new Number.Literal();
 
     @Deployment
     public static WebArchive createTestArchive() {
@@ -83,13 +80,11 @@ public class ResolutionByTypeTest extends AbstractTest {
             @SpecAssertion(section = MULTIPLE_QUALIFIERS, id = "a"), @SpecAssertion(section = MULTIPLE_QUALIFIERS, id = "d") })
     public void testAllQualifiersSpecifiedForResolutionMustAppearOnBean() {
 
-        Set<Bean<Animal>> animalBeans = getBeans(Animal.class, new ChunkyLiteral(), new AnnotationLiteral<Whitefish>() {
-        });
+        Set<Bean<Animal>> animalBeans = getBeans(Animal.class, new ChunkyLiteral(), new Whitefish.Literal());
         assertEquals(animalBeans.size(), 1);
         assertTrue(animalBeans.iterator().next().getTypes().contains(Cod.class));
 
-        Set<Bean<ScottishFish>> scottishFishBeans = getBeans(ScottishFish.class, new AnnotationLiteral<Whitefish>() {
-        });
+        Set<Bean<ScottishFish>> scottishFishBeans = getBeans(ScottishFish.class, new Whitefish.Literal());
         assertEquals(scottishFishBeans.size(), 2);
 
         for (Bean<ScottishFish> bean : scottishFishBeans) {
@@ -124,10 +119,8 @@ public class ResolutionByTypeTest extends AbstractTest {
         assertEquals(getBeans(Double.class, NUMBER).size(), 2);
         assertEquals(getBeans(double.class, NUMBER).size(), 2);
 
-        Double min = getContextualReference(Double.class, new AnnotationLiteral<Min>() {
-        });
-        double max = getContextualReference(double.class, new AnnotationLiteral<Max>() {
-        });
+        Double min = getContextualReference(Double.class, new Min.Literal());
+        double max = getContextualReference(double.class, new Max.Literal());
 
         assertEquals(min, Double.valueOf(NumberProducer.min));
         assertEquals(Double.valueOf(max), NumberProducer.max);
@@ -146,8 +139,7 @@ public class ResolutionByTypeTest extends AbstractTest {
                 return true;
             }
 
-        }, new AnnotationLiteral<Whitefish>() {
-        });
+        }, new Whitefish.Literal());
         assertEquals(beans.size(), 2);
 
         Set<Type> classes = new HashSet<Type>();

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Tame.java
@@ -25,11 +25,13 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
 @Retention(RUNTIME)
 @Qualifier
 public @interface Tame {
-
+    class Literal extends AnnotationLiteral<Tame> implements Tame {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Whitefish.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Whitefish.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Whitefish {
-
+    class Literal extends AnnotationLiteral<Whitefish> implements Whitefish {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Wild.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Wild.java
@@ -25,11 +25,13 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
 @Retention(RUNTIME)
 @Qualifier
 public @interface Wild {
-
+    class Literal extends AnnotationLiteral<Wild> implements Wild {
+    }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/vetoed/VetoedTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/vetoed/VetoedTest.java
@@ -61,8 +61,7 @@ public class VetoedTest extends AbstractTest {
     public void testPackageLevelVeto() {
         assertEquals(getCurrentManager().getBeans(Piranha.class, Any.Literal.INSTANCE).size(), 0);
         assertEquals(getCurrentManager().getBeans(Shark.class, Any.Literal.INSTANCE).size(), 1);
-        assertEquals(getCurrentManager().getBeans(Shark.class, new AnnotationLiteral<Fishy>() {
-        }).size(), 1);
+        assertEquals(getCurrentManager().getBeans(Shark.class, new Fishy.Literal()).size(), 1);
     }
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/vetoed/aquarium/Fishy.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/vetoed/aquarium/Fishy.java
@@ -22,6 +22,7 @@ import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 import java.lang.annotation.Documented;
@@ -33,5 +34,6 @@ import java.lang.annotation.Target;
 @Documented
 @Qualifier
 public @interface Fishy {
-
+    class Literal extends AnnotationLiteral<Fishy> implements Fishy {
+    }
 }

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/EnterpriseInterceptorBindingResolutionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/EnterpriseInterceptorBindingResolutionTest.java
@@ -71,12 +71,12 @@ public class EnterpriseInterceptorBindingResolutionTest extends AbstractTest {
         // Test interceptor is resolved (note non-binding member of BallBinding)
         assertEquals(
                 getCurrentManager().resolveInterceptors(InterceptionType.AROUND_INVOKE,
-                        new AnnotationLiteral<MessageBinding>() {
-                        }, new AnnotationLiteral<LoggedBinding>() {
-                        }, new AnnotationLiteral<TransactionalBinding>() {
-                        }, new AnnotationLiteral<PingBinding>() {
-                        }, new AnnotationLiteral<PongBinding>() {
-                        }, new BallBindingLiteral(true, true)).size(), 1);
+                        new MessageBinding.Literal(),
+                        new LoggedBinding.Literal(),
+                        new TransactionalBinding.Literal(),
+                        new PingBinding.Literal(),
+                        new PongBinding.Literal(),
+                        new BallBindingLiteral(true, true)).size(), 1);
 
         // Test the set of interceptor bindings
         assertNotNull(messageService);
@@ -115,15 +115,15 @@ public class EnterpriseInterceptorBindingResolutionTest extends AbstractTest {
         // Test interceptor is resolved (note non-binding member of BallBinding)
         assertEquals(
                 getCurrentManager().resolveInterceptors(InterceptionType.POST_CONSTRUCT,
-                        new AnnotationLiteral<MessageBinding>() {
-                        }, new AnnotationLiteral<LoggedBinding>() {
-                        }, new AnnotationLiteral<TransactionalBinding>() {
-                        }, new BasketBindingLiteral(true, true)).size(), 1);
+                        new MessageBinding.Literal(),
+                        new LoggedBinding.Literal(),
+                        new TransactionalBinding.Literal(),
+                        new BasketBindingLiteral(true, true)).size(), 1);
         assertEquals(
-                getCurrentManager().resolveInterceptors(InterceptionType.PRE_DESTROY, new AnnotationLiteral<MessageBinding>() {
-                }, new AnnotationLiteral<LoggedBinding>() {
-                }, new AnnotationLiteral<TransactionalBinding>() {
-                }, new BasketBindingLiteral(true, true)).size(), 1);
+                getCurrentManager().resolveInterceptors(InterceptionType.PRE_DESTROY, new MessageBinding.Literal(),
+                new LoggedBinding.Literal(),
+                new TransactionalBinding.Literal(),
+                new BasketBindingLiteral(true, true)).size(), 1);
 
         // Test the set of interceptor bindings
         ComplicatedLifecycleInterceptor.reset();

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/LoggedBinding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/LoggedBinding.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.interceptor.InterceptorBinding;
 
 @Target({ TYPE })
@@ -32,4 +33,6 @@ import jakarta.interceptor.InterceptorBinding;
 @Documented
 @InterceptorBinding
 public @interface LoggedBinding {
+    class Literal extends AnnotationLiteral<LoggedBinding> implements LoggedBinding {
+    }
 }

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/MessageBinding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/MessageBinding.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.interceptor.InterceptorBinding;
 
 @Target({ TYPE })
@@ -32,4 +33,6 @@ import jakarta.interceptor.InterceptorBinding;
 @Documented
 @InterceptorBinding
 public @interface MessageBinding {
+    class Literal extends AnnotationLiteral<MessageBinding> implements MessageBinding {
+    }
 }

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/PingBinding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/PingBinding.java
@@ -25,6 +25,7 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.interceptor.InterceptorBinding;
 
 @Target({ TYPE, METHOD })
@@ -34,4 +35,6 @@ import jakarta.interceptor.InterceptorBinding;
 @Documented
 @InterceptorBinding
 public @interface PingBinding {
+    class Literal extends AnnotationLiteral<PingBinding> implements PingBinding {
+    }
 }

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/PongBinding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/PongBinding.java
@@ -25,6 +25,7 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.interceptor.InterceptorBinding;
 
 @Target({ TYPE, METHOD })
@@ -34,4 +35,6 @@ import jakarta.interceptor.InterceptorBinding;
 @Documented
 @InterceptorBinding
 public @interface PongBinding {
+    class Literal extends AnnotationLiteral<PongBinding> implements PongBinding {
+    }
 }

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/TransactionalBinding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/TransactionalBinding.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.interceptor.InterceptorBinding;
 
 @Target({ TYPE })
@@ -32,4 +33,6 @@ import jakarta.interceptor.InterceptorBinding;
 @Documented
 @InterceptorBinding
 public @interface TransactionalBinding {
+    class Literal extends AnnotationLiteral<TransactionalBinding> implements TransactionalBinding {
+    }
 }

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/resource/DatabaseProduction.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/resource/DatabaseProduction.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,4 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface DatabaseProduction {
+    class Literal extends AnnotationLiteral<DatabaseProduction> implements DatabaseProduction {
+    }
 }

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/resource/DatabaseTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/resource/DatabaseTest.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,4 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface DatabaseTest {
+    class Literal extends AnnotationLiteral<DatabaseTest> implements DatabaseTest {
+    }
 }

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/resource/ResourceAlternativeAvailabilityTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/resource/ResourceAlternativeAvailabilityTest.java
@@ -61,10 +61,8 @@ public class ResourceAlternativeAvailabilityTest extends AbstractTest {
     @SpecAssertion(section = DECLARING_SELECTED_ALTERNATIVES_BEAN_ARCHIVE, id = "cc")
     public void testResourceAvailability() {
 
-        AnnotationLiteral<DatabaseTest> testLiteral = new AnnotationLiteral<DatabaseTest>() {
-        };
-        AnnotationLiteral<DatabaseProduction> productionLiteral = new AnnotationLiteral<DatabaseProduction>() {
-        };
+        AnnotationLiteral<DatabaseTest> testLiteral = new DatabaseTest.Literal();
+        AnnotationLiteral<DatabaseProduction> productionLiteral = new DatabaseProduction.Literal();
         Set<Bean<EntityManager>> beans = getBeans(EntityManager.class, testLiteral);
         assertEquals(beans.size(), 1);
         beans = getBeans(EntityManager.class, productionLiteral);

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/disposer/ApplicationContextDisposerTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/disposer/ApplicationContextDisposerTest.java
@@ -57,8 +57,7 @@ public class ApplicationContextDisposerTest extends AbstractTest {
     public void testApplicationContextActiveDuringDispose() {
         logger.log("Injected forest: {0}", forest.toString());
         @SuppressWarnings("serial")
-        Bean<Mushroom> bean = getUniqueBean(Mushroom.class, new AnnotationLiteral<Edible>() {
-        });
+        Bean<Mushroom> bean = getUniqueBean(Mushroom.class, new Edible.Literal());
         CreationalContext<Mushroom> ctx = getCurrentManager().createCreationalContext(bean);
         Mushroom mushroom = bean.create(ctx);
         assertEquals(mushroom.getName(), "Boletus");

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/disposer/Edible.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/disposer/Edible.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Edible {
-
+    class Literal extends AnnotationLiteral<Edible> implements Edible {
+    }
 }

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/Mock.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/Mock.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,4 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Mock {
+    class Literal extends AnnotationLiteral<Mock> implements Mock {
+    }
 }

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/SessionBeanTypesTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/SessionBeanTypesTest.java
@@ -99,8 +99,7 @@ public class SessionBeanTypesTest extends AbstractTest {
     @SpecAssertion(section = SESSION_BEAN_TYPES, id = "ba")
     public void testSessionBeanExtendingSessionBeanWithLocalClientView() {
         // no-interface view
-        Bean<MockLoginActionBean> loginBean = getUniqueBean(MockLoginActionBean.class, new AnnotationLiteral<Mock>() {
-        });
+        Bean<MockLoginActionBean> loginBean = getUniqueBean(MockLoginActionBean.class, new Mock.Literal());
         assertNotNull(loginBean);
         // MockLoginActionBean, LoginActionBean, Object
         assertEquals(loginBean.getTypes().size(), 3);

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/InterceptorExtension.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/InterceptorExtension.java
@@ -51,8 +51,7 @@ public class InterceptorExtension implements Extension {
                 methods = new HashSet<AnnotatedMethod<? super Suffixed>>();
                 for (AnnotatedMethod<? super Suffixed> method : super.getMethods()) {
                     if ("value".equals(method.getJavaMember().getName())) {
-                        methods.add(new AnnotatedMethodWrapper<Suffixed>((AnnotatedMethod<Suffixed>) method, this, true, new AnnotationLiteral<Nonbinding>() {
-                        }));
+                        methods.add(new AnnotatedMethodWrapper<Suffixed>((AnnotatedMethod<Suffixed>) method, this, true, new Nonbinding.Literal()));
                     } else {
                         methods.add(new AnnotatedMethodWrapper<Suffixed>((AnnotatedMethod<Suffixed>) method, this, true));
                     }

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/EnterpriseBeanDefinitionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/EnterpriseBeanDefinitionTest.java
@@ -140,8 +140,7 @@ public class EnterpriseBeanDefinitionTest extends AbstractTest {
     @Test
     @SpecAssertion(section = DECLARING_SESSION_BEAN, id = "be")
     public void testBeanWithQualifiers() {
-        Annotation tame = new AnnotationLiteral<Tame>() {
-        };
+        Annotation tame = new Tame.Literal();
         Bean<ApeLocal> apeBean = getBeans(ApeLocal.class, tame).iterator().next();
         assert apeBean.getQualifiers().contains(tame);
     }

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/Tame.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/Tame.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Tame {
-
+    class Literal extends AnnotationLiteral<Tame> implements Tame {
+    }
 }

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/RemoteInterfaceNotInAPITypesTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/RemoteInterfaceNotInAPITypesTest.java
@@ -51,8 +51,7 @@ public class RemoteInterfaceNotInAPITypesTest extends AbstractTest {
             @SpecAssertion(section = SESSION_BEAN_TYPES, id = "c"), @SpecAssertion(section = SESSION_BEAN_TYPES, id = "aa") })
     public void testRemoteInterfacesAreNotInAPITypes() {
         // only remote view
-        Bean<Object> collieBean = getUniqueBean(Object.class, new AnnotationLiteral<Tame>() {
-        });
+        Bean<Object> collieBean = getUniqueBean(Object.class, new Tame.Literal());
         assertNotNull(collieBean);
         assertTypeSetMatches(collieBean.getTypes(), Object.class);
 

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/Tame.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/Tame.java
@@ -10,6 +10,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -17,5 +18,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Tame {
-
+    class Literal extends AnnotationLiteral<Tame> implements Tame {
+    }
 }

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/EnterpriseBeanLifecycleTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/EnterpriseBeanLifecycleTest.java
@@ -73,15 +73,13 @@ public class EnterpriseBeanLifecycleTest extends AbstractTest {
         GrossStadt frankfurt = getContextualReference(GrossStadt.class);
         Bean<KleinStadt> stadtBean = getBeans(KleinStadt.class).iterator().next();
         assert stadtBean != null : "Expected a bean for stateful session bean Kassel";
-        KleinStadt stadtInstance = getContextualReference(KleinStadt.class, new AnnotationLiteral<Important>() {
-        });
+        KleinStadt stadtInstance = getContextualReference(KleinStadt.class, new Important.Literal());
         assert stadtInstance != null : "Expected instance to be created by container";
         assert frankfurt.isKleinStadtCreated() : "PostConstruct should be invoked when bean instance is created";
         frankfurt.resetCreatedFlags();
 
         // Create a second one to make sure create always does create a new session bean
-        KleinStadt anotherStadtInstance = getContextualReference(KleinStadt.class, new AnnotationLiteral<Important>() {
-        });
+        KleinStadt anotherStadtInstance = getContextualReference(KleinStadt.class, new Important.Literal());
         assert anotherStadtInstance != null : "Expected second instance of session bean";
         assert frankfurt.isKleinStadtCreated();
         assert anotherStadtInstance != stadtInstance : "create() should not return same bean as before";
@@ -99,8 +97,7 @@ public class EnterpriseBeanLifecycleTest extends AbstractTest {
     @SpecAssertions({ @SpecAssertion(section = PASSIVATION_CAPABLE_DEPENDENCY_EE, id = "ac") })
     public void testSerializeSFSB() throws Exception {
 
-        KleinStadt stadtInstance = getContextualReference(KleinStadt.class, new AnnotationLiteral<Important>() {
-        });
+        KleinStadt stadtInstance = getContextualReference(KleinStadt.class, new Important.Literal());
 
         byte[] bytes = passivate(stadtInstance);
         Object object = activate(bytes);
@@ -130,8 +127,7 @@ public class EnterpriseBeanLifecycleTest extends AbstractTest {
     @Test(groups =  INTEGRATION)
     @SpecAssertions({ @SpecAssertion(section = STATELESS_LIFECYCLE, id = "c"), @SpecAssertion(section = SESSION_BEAN_EJB_REMOVE_METHOD, id = "dba") })
     public void testRemovedEjbIgnored() {
-        KleinStadt stadtInstance = getContextualReference(KleinStadt.class, new AnnotationLiteral<Important>() {
-        });
+        KleinStadt stadtInstance = getContextualReference(KleinStadt.class, new Important.Literal());
         assert stadtInstance != null : "Expected instance to be created by container";
         stadtInstance.setName("Kassel-Wilhelmshoehe");
         stadtInstance.zustandVergessen();

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/Important.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/Important.java
@@ -27,6 +27,7 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 /**
@@ -38,4 +39,6 @@ import jakarta.inject.Qualifier;
 @Qualifier
 @Inherited
 public @interface Important {
+    class Literal extends AnnotationLiteral<Important> implements Important {
+    }
 }

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/enterprise/EnterpriseProducerFieldDefinitionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/enterprise/EnterpriseProducerFieldDefinitionTest.java
@@ -42,10 +42,8 @@ public class EnterpriseProducerFieldDefinitionTest extends AbstractTest {
     @Test(groups = INTEGRATION)
     @SpecAssertions({ @SpecAssertion(section = PRODUCER_FIELD, id = "a"), @SpecAssertion(section = PRODUCER_FIELD_EE, id = "a") })
     public void testStaticProducerField() {
-        assert getContextualReference(Egg.class, new AnnotationLiteral<Foo>() {
-        }) != null;
-        assert getContextualReference(Egg.class, new AnnotationLiteral<Foo>() {
-        }).getSize() == Chicken.SIZE;
+        assert getContextualReference(Egg.class, new Foo.Literal()) != null;
+        assert getContextualReference(Egg.class, new Foo.Literal()).getSize() == Chicken.SIZE;
     }
 
 }

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/enterprise/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/enterprise/Foo.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Foo {
-
+    class Literal extends AnnotationLiteral<Foo> implements Foo {
+    }
 }

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/EnterpriseProducerMethodDefinitionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/EnterpriseProducerMethodDefinitionTest.java
@@ -46,26 +46,21 @@ public class EnterpriseProducerMethodDefinitionTest extends AbstractTest {
     @Test(groups = INTEGRATION, expectedExceptions = UnsatisfiedResolutionException.class)
     @SpecAssertion(section = MEMBER_LEVEL_INHERITANCE_EE, id = "dd")
     public void testNonStaticProducerMethodNotInheritedBySpecializingSubclass() {
-        assertEquals(getBeans(Egg.class, new AnnotationLiteral<Yummy>() {
-        }).size(), 0);
-        getContextualReference(Egg.class, new AnnotationLiteral<Yummy>() {
-        }).getMother();
+        assertEquals(getBeans(Egg.class, new Yummy.Literal()).size(), 0);
+        getContextualReference(Egg.class, new Yummy.Literal()).getMother();
     }
 
     @Test(groups = INTEGRATION)
     @SpecAssertion(section = MEMBER_LEVEL_INHERITANCE_EE, id = "dd")
     public void testNonStaticProducerMethodNotInherited() {
-        assertEquals(getBeans(Apple.class, new AnnotationLiteral<Yummy>() {
-        }).size(), 1);
-        assertTrue(getContextualReference(Apple.class, new AnnotationLiteral<Yummy>() {
-        }).getTree() instanceof AppleTree);
+        assertEquals(getBeans(Apple.class, new Yummy.Literal()).size(), 1);
+        assertTrue(getContextualReference(Apple.class, new Yummy.Literal()).getTree() instanceof AppleTree);
     }
 
     @Test(groups = INTEGRATION)
     @SpecAssertion(section = MEMBER_LEVEL_INHERITANCE_EE, id = "dj")
     public void testNonStaticProducerMethodNotIndirectlyInherited() {
-        Set<Bean<Pear>> beans = getBeans(Pear.class, new AnnotationLiteral<Yummy>() {
-        });
+        Set<Bean<Pear>> beans = getBeans(Pear.class, new Yummy.Literal());
         assertEquals(beans.size(), 2);
     }
 }

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/Yummy.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/Yummy.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Yummy {
-
+    class Literal extends AnnotationLiteral<Yummy> implements Yummy {
+    }
 }

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/EjbInjectionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/EjbInjectionTest.java
@@ -74,8 +74,7 @@ public class EjbInjectionTest extends AbstractTest {
     @SpecAssertions({ @SpecAssertion(section = RESOURCE_TYPES, id = "ad") })
     public void testResourceBeanTypes() {
         @SuppressWarnings("serial")
-        Bean<BeanRemote> beanRemote = getBeans(BeanRemote.class, new AnnotationLiteral<Lazy>() {
-        }).iterator().next();
+        Bean<BeanRemote> beanRemote = getBeans(BeanRemote.class, new Lazy.Literal()).iterator().next();
         assert beanRemote.getTypes().size() == 3;
         assert typeSetMatches(beanRemote.getTypes(), BeanRemote.class, Object.class, AnotherInterface.class);
     }

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/Lazy.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/Lazy.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Lazy {
-
+    class Literal extends AnnotationLiteral<Lazy> implements Lazy {
+    }
 }

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/env/EnvInjectionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/env/EnvInjectionTest.java
@@ -67,8 +67,7 @@ public class EnvInjectionTest extends AbstractTest {
             @SpecAssertion(section = RESOURCE_LIFECYCLE, id = "o") })
     public void testProduceEnvProxy() {
         @SuppressWarnings("serial")
-        Bean<String> greetingEnvBean = getBeans(String.class, new AnnotationLiteral<Greeting>() {
-        }).iterator().next();
+        Bean<String> greetingEnvBean = getBeans(String.class, new Greeting.Literal()).iterator().next();
         CreationalContext<String> greetingEnvCc = getCurrentManager().createCreationalContext(greetingEnvBean);
         String greeting = greetingEnvBean.create(greetingEnvCc);
         assert greeting != null;
@@ -79,8 +78,7 @@ public class EnvInjectionTest extends AbstractTest {
     @SpecAssertions({ @SpecAssertion(section = RESOURCE_TYPES, id = "aa") })
     public void testResourceBeanTypes() {
         @SuppressWarnings("serial")
-        Bean<Boolean> check = getBeans(Boolean.class, new AnnotationLiteral<Greeting>() {
-        }).iterator().next();
+        Bean<Boolean> check = getBeans(Boolean.class, new Greeting.Literal()).iterator().next();
 
         // Build the expected types from the JVM Boolean.class to avoid issues as the java.lang types evolve
         ArrayList<Class<?>> classes = new ArrayList<>();

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/env/Greeting.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/env/Greeting.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,4 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Greeting {
+    class Literal extends AnnotationLiteral<Greeting> implements Greeting {
+    }
 }

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/Database.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/Database.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,4 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Database {
+    class Literal extends AnnotationLiteral<Database> implements Database {
+    }
 }

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/PersistenceContextInjectionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/PersistenceContextInjectionTest.java
@@ -100,8 +100,7 @@ public class PersistenceContextInjectionTest extends AbstractTest {
     @Test
     @SpecAssertions({ @SpecAssertion(section = DECLARING_RESOURCE, id = "hh"), @SpecAssertion(section = RESOURCE_TYPES, id = "ab") })
     public void testBeanTypesAndBindingTypesOfPersistenceContext() {
-        Bean<EntityManager> manager = getBeans(EntityManager.class, new AnnotationLiteral<Database>() {
-        }).iterator().next();
+        Bean<EntityManager> manager = getBeans(EntityManager.class, new Database.Literal()).iterator().next();
         assert manager.getTypes().size() == 3;
         assert typeSetMatches(manager.getTypes(), EntityManager.class, Object.class, AutoCloseable.class);
         assert manager.getQualifiers().size() == 2;
@@ -111,8 +110,7 @@ public class PersistenceContextInjectionTest extends AbstractTest {
     @Test
     @SpecAssertions({ @SpecAssertion(section = RESOURCE_TYPES, id = "ac") })
     public void testBeanTypesOfPersistenceUnit() {
-        Bean<EntityManagerFactory> factory = getBeans(EntityManagerFactory.class, new AnnotationLiteral<Database>() {
-        }).iterator().next();
+        Bean<EntityManagerFactory> factory = getBeans(EntityManagerFactory.class, new Database.Literal()).iterator().next();
         assert factory.getTypes().size() == 3;
         assert typeSetMatches(factory.getTypes(), EntityManagerFactory.class, Object.class, AutoCloseable.class);
     }

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/resource/Another.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/resource/Another.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,4 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Another {
+    class Literal extends AnnotationLiteral<Another> implements Another {
+    }
 }

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/resource/InjectionOfResourceTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/resource/InjectionOfResourceTest.java
@@ -58,8 +58,7 @@ public class InjectionOfResourceTest extends AbstractTest {
     @SpecAssertions({ @SpecAssertion(section = RESOURCE_LIFECYCLE, id = "la"), @SpecAssertion(section = RESOURCE_LIFECYCLE, id = "ma"),
             @SpecAssertion(section = RESOURCE_LIFECYCLE, id = "o") })
     public void testProduceResourceProxy() {
-        Bean<BeanManager> beanManagerBean = getBeans(BeanManager.class, new AnnotationLiteral<Another>() {
-        }).iterator().next();
+        Bean<BeanManager> beanManagerBean = getBeans(BeanManager.class, new Another.Literal()).iterator().next();
         CreationalContext<BeanManager> beanManagerCc = getCurrentManager().createCreationalContext(beanManagerBean);
         BeanManager beanManager = beanManagerBean.create(beanManagerCc);
         assert beanManager != null;
@@ -78,8 +77,7 @@ public class InjectionOfResourceTest extends AbstractTest {
     @Test
     @SpecAssertions({ @SpecAssertion(section = RESOURCE_TYPES, id = "aa") })
     public void testResourceBeanTypes() {
-        Bean<BeanManager> beanRemote = getBeans(BeanManager.class, new AnnotationLiteral<Another>() {
-        }).iterator().next();
+        Bean<BeanManager> beanRemote = getBeans(BeanManager.class, new Another.Literal()).iterator().next();
         assert beanRemote.getTypes().size() == 3;
         assert beanRemote.getTypes().contains(BeanManager.class);
         assert beanRemote.getTypes().contains(BeanContainer.class);

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/EnterpriseBeanSpecializationTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/EnterpriseBeanSpecializationTest.java
@@ -44,8 +44,7 @@ import org.testng.annotations.Test;
 public class EnterpriseBeanSpecializationTest extends AbstractTest {
 
     @SuppressWarnings("serial")
-    private static Annotation LANDOWNER_LITERAL = new AnnotationLiteral<Landowner>() {
-    };
+    private static Annotation LANDOWNER_LITERAL = new Landowner.Literal();
 
     @Deployment
     public static WebArchive createTestArchive() {

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/Landowner.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/Landowner.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Landowner {
-
+    class Literal extends AnnotationLiteral<Landowner> implements Landowner {
+    }
 }

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/producer/method/enterprise/EnterpriseProducerMethodSpecializationTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/producer/method/enterprise/EnterpriseProducerMethodSpecializationTest.java
@@ -47,11 +47,9 @@ import org.testng.annotations.Test;
 public class EnterpriseProducerMethodSpecializationTest extends AbstractTest {
 
     @SuppressWarnings("serial")
-    private static Annotation EXPENSIVE_LITERAL = new AnnotationLiteral<Expensive>() {
-    };
+    private static Annotation EXPENSIVE_LITERAL = new Expensive.Literal();
     @SuppressWarnings("serial")
-    private static Annotation SPARKLY_LITERAL = new AnnotationLiteral<Sparkly>() {
-    };
+    private static Annotation SPARKLY_LITERAL = new Sparkly.Literal();
 
     @Deployment
     public static WebArchive createTestArchive() {

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/producer/method/enterprise/Expensive.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/producer/method/enterprise/Expensive.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Expensive {
-
+    class Literal extends AnnotationLiteral<Expensive> implements Expensive {
+    }
 }

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/producer/method/enterprise/Sparkly.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/producer/method/enterprise/Sparkly.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -33,5 +34,6 @@ import jakarta.inject.Qualifier;
 @Documented
 @Qualifier
 public @interface Sparkly {
-
+    class Literal extends AnnotationLiteral<Sparkly> implements Sparkly {
+    }
 }


### PR DESCRIPTION
The `Annotation.equals()` contract directly states that for two annotation objects to be equal, they must (among others) both implement the [same] annotation interface.

The CDI TCK used to create instances of memberless annotations simply by instantiating an anonymous subclass of `AnnotationLiteral`, which doesn't implement the annotation interface and hence is invalid.

It has never been a problem, because `AnnotationLiteral` implements equality in a slightly more permissive manner: instead of checking that both objects implement the same annotation interface, it checks that both objects are annotations that have an equal `annotationType()`. It becomes problematic when an implementation uses a different mechanism to instantiate annotations than extending `AnnotationLiteral`, one that closely follows the `Annotation` contract. 

This commit replaces all usages of such anonymous subclasses by proper `AnnotationLiteral` subclasses that implement the annotation interface as well.