### PR TITLE
431: Disable Breaking Test

### DIFF
--- a/impl/src/main/resources/tck-tests.xml
+++ b/impl/src/main/resources/tck-tests.xml
@@ -23,7 +23,12 @@
         </packages>
 
         <classes>
-            <!-- Add excluded tests here -->
+            <!-- CDITCK-431 -->
+            <class name="org.jboss.cdi.tck.tests.full.extensions.lifecycle.bbd.broken.passivatingScope.AddingPassivatingScopeTest">
+                <methods>
+                    <exclude name=".*"/>
+                </methods>
+            </class>
         </classes>
 
     </test>


### PR DESCRIPTION
The changes made for https://github.com/jakartaee/cdi-tck/issues/431 do not work with Weld, which has already passed the TCK on a previous release. Per the Jakarta EE TCK Process, this type of change is not allowed in response to an accepted challenge.

Disabling the test instead, so all implementations can pass the TCK.