### PR TITLE
Selenium Fix for Chromium v111+

### DIFF
--- a/web/src/main/java/org/jboss/cdi/tck/selenium/ChromeDevtoolsDriver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/selenium/ChromeDevtoolsDriver.java
@@ -515,6 +515,7 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
         options.addArguments("--no-sandbox");
         options.addArguments("--disable-web-security");
         options.addArguments("--allow-insecure-localhost");
+        options.addArguments("--remote-allow-origins=*");
         options.addArguments("--ignore-urlfetcher-cert-requests");
         options.addArguments("--auto-open-devtools-for-tabs");
         options.addArguments("--disable-gpu");


### PR DESCRIPTION
The new version of Chrome (111, released Mar 7th) has included some security updates that disable the websocket connection between the web driver and the browser. This fix is needed to continue testing with current versions of Chrome. The alternative would be to only test with versions no newer than 110, but Google does not make it easy to find back-level versions.

For a full discussion on the change, see: https://groups.google.com/g/chromedriver-users/c/xL5-13_qGaA