### PR TITLE
move DestroyForSameCreationalContext2Test to the "full" part of the TCK

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/DestroyForSameCreationalContext2Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/DestroyForSameCreationalContext2Test.java
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.context;
+package org.jboss.cdi.tck.tests.full.context;
 
+import static org.jboss.cdi.tck.TestGroups.CDI_FULL;
 import static org.jboss.cdi.tck.cdi.Sections.CONTEXT;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -45,7 +46,7 @@ public class DestroyForSameCreationalContext2Test extends AbstractTest {
         return new WebArchiveBuilder().withTestClassPackage(DestroyForSameCreationalContext2Test.class).build();
     }
 
-    @Test
+    @Test(groups = CDI_FULL)
     @SpecAssertion(section = CONTEXT, id = "r")
     public void testDestroyForSameCreationalContextOnly() {
         // Check that the mock cc is called (via cc.release()) when we request a context destroyed

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/DummyContextual.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/DummyContextual.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.context;
+package org.jboss.cdi.tck.tests.full.context;
 
 import jakarta.enterprise.context.spi.Contextual;
 import jakarta.enterprise.context.spi.CreationalContext;


### PR DESCRIPTION
Fixes #457