### PR TITLE
fix test that interceptors are dependent instances of intercepted beans

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/DependentContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/DependentContextTest.java
@@ -414,7 +414,13 @@ public class DependentContextTest extends AbstractTest {
     @Test
     @SpecAssertion(section = DEPENDENT_OBJECTS, id = "aa")
     public void testDependentScopedInterceptorsAreDependentObjectsOfBean() {
-        TransactionalInterceptor.destroyed = false;
+        // since interceptors can't declare `@PreDestroy` callbacks for themselves, we inject
+        // another dependent-scoped bean into the interceptor and add a `@PreDestroy` callback
+        // there -- this dependency will be a dependent instance of the interceptor, and so
+        // if destroying the intercepted bean will destroy the other bean, we have a proof
+        // that the interceptor was also destroyed
+
+        TransactionalInterceptorDependency.destroyed = false;
         TransactionalInterceptor.intercepted = false;
 
         Bean<AccountTransaction> bean = getBeans(AccountTransaction.class).iterator().next();
@@ -427,6 +433,6 @@ public class DependentContextTest extends AbstractTest {
 
         ctx.release();
 
-        assert TransactionalInterceptor.destroyed;
+        assert TransactionalInterceptorDependency.destroyed;
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/TransactionalInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/TransactionalInterceptor.java
@@ -16,9 +16,9 @@
  */
 package org.jboss.cdi.tck.tests.context.dependent;
 
-import jakarta.annotation.PreDestroy;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
 import jakarta.interceptor.AroundInvoke;
 import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
@@ -28,23 +28,14 @@ import jakarta.interceptor.InvocationContext;
 @Interceptor
 @Priority(1)
 public class TransactionalInterceptor {
-    public static boolean destroyed = false;
     public static boolean intercepted = false;
+
+    @Inject
+    TransactionalInterceptorDependency dependency;
 
     @AroundInvoke
     public Object alwaysReturnThis(InvocationContext ctx) throws Exception {
         intercepted = true;
         return ctx.proceed();
-    }
-
-    @PreDestroy
-    public void destroy(InvocationContext ctx) {
-        destroyed = true;
-        try {
-            ctx.proceed();
-        } catch (Exception e) {
-            // catch and wrap
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/TransactionalInterceptorDependency.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/TransactionalInterceptorDependency.java
@@ -1,0 +1,14 @@
+package org.jboss.cdi.tck.tests.context.dependent;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
+public class TransactionalInterceptorDependency {
+    public static boolean destroyed = false;
+
+    @PreDestroy
+    public void destroy() {
+        destroyed = true;
+    }
+}


### PR DESCRIPTION
The test previously used a `@PreDestroy` callback declared on the interceptor to prove that the interceptor is destroyed when the intercepted bean is destroyed, which is incorrect. Interceptors cannot declare lifecycle callbacks for themselves, the `@PreDestroy` callback actually interposed on the destruction of the intercepted bean.

This commit uses a new dependent-scoped bean that is injected into the interceptor, which makes it a dependent instance of the interceptor. The new bean has a `@PreDestroy` callback for itself, which means we can verify that the new bean is destroyed when the intercepted bean is destroyed. Such chain of dependent instance destruction proves that the interceptor is indeed a dependent instance of the intercepted bean.

Fixes #454