### PR TITLE
Change InvocationContextTest#testGetTargetMethod() to avoid using recursive interception

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor1.java
@@ -25,21 +25,16 @@ import jakarta.interceptor.InvocationContext;
 @Binding1
 @Priority(100)
 public class Interceptor1 {
-    private static boolean getTargetOK = false;
+    private static SimpleBean target;
 
     @AroundInvoke
     public Object aroundInvoke(InvocationContext ctx) throws Exception {
-        SimpleBean target = (SimpleBean) ctx.getTarget();
-        int id1 = target.getId();
-        int id2 = (Integer) ctx.proceed();
-
-        if (id1 == id2) {
-            getTargetOK = true;
-        }
-        return id1;
+        // bean is not normal scoped therefore getTarget() will return contextual instance
+        target = (SimpleBean) ctx.getTarget();
+        return ctx.proceed();
     }
 
-    public static boolean isGetTargetOK() {
-        return getTargetOK;
+    public static SimpleBean getTarget() {
+        return target;
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/InvocationContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/InvocationContextTest.java
@@ -20,6 +20,7 @@ import static org.jboss.cdi.tck.interceptors.InterceptorsSections.CONSTRUCTOR_AN
 import static org.jboss.cdi.tck.interceptors.InterceptorsSections.INVOCATIONCONTEXT;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -48,10 +49,11 @@ public class InvocationContextTest extends AbstractTest {
     @SpecAssertion(section = CONSTRUCTOR_AND_METHOD_LEVEL_INT, id = "aa")
     @SpecAssertion(section = INVOCATIONCONTEXT, id = "c")
     public void testGetTargetMethod() {
+        // bean is dependent, contextual ref = contextual instance
         SimpleBean instance = getContextualReference(SimpleBean.class);
         instance.setId(10);
         assertEquals(instance.getId(), 10);
-        assertTrue(Interceptor1.isGetTargetOK());
+        assertSame(Interceptor1.getTarget(), instance);
     }
 
     @Test


### PR DESCRIPTION
Fixes #464 

This PR changes the test in question to test return value of `InvocationContetx#getTarget()` without relying on recursive interception. Verified with Weld and Arc.

PR is a draft until linked issue gets the `accepted` label.