### PR TITLE
Correct the deployment setup of EmptyBeansXmlDiscoveryTest

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/shrinkwrap/ArchiveBuilder.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/shrinkwrap/ArchiveBuilder.java
@@ -171,7 +171,9 @@ public abstract class ArchiveBuilder<T extends ArchiveBuilder<T, A>, A extends A
      * Add <code>beans.xml</code> located in src/main/resource/{testPackagePath}.
      * <p/>
      * <p>
-     * Do not use this in new tests - use {@link #withBeansXml(BeansXml)} instead.
+     * In most cases, the alternative method {@link #withBeansXml(BeansXml)} should be used instead.
+     * However, this variant is still useful if the test needs a very specific beans.xml file such as completely empty
+     * file or one with invalid format.
      * </p>
      *
      * @param beansXml

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/EmptyBeansXmlDiscoveryTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/EmptyBeansXmlDiscoveryTest.java
@@ -7,20 +7,21 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.CDI;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
 /**
  * Tests that a singular archive with empty beans.xml results in annotated discovery mode.
  */
+@SpecVersion(spec = "cdi", version = "4.0")
 public class EmptyBeansXmlDiscoveryTest extends AbstractTest {
 
     @Deployment
     public static WebArchive createTestArchive() {
-        return ShrinkWrap.create(WebArchive.class).addClasses(SomeAnnotatedBean.class, SomeUnannotatedBean.class)
-                .addAsWebInfResource(new StringAsset(""), "beans.xml");
+        return new WebArchiveBuilder().withTestClassPackage(EmptyBeansXmlDiscoveryTest.class)
+                .withBeansXml("beans.xml").build();
     }
 
     @Test(dataProvider = ARQUILLIAN_DATA_PROVIDER)


### PR DESCRIPTION
Fixes #470 

Changes how the test deployment is created - doesn't change the functionality or contents of the test.