### PR TITLE
Change ProcessBeanAttributesNotFiredForBuiltinBean to only detect PBA for beans with @Default qualifiers

### DIFF
--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processBeanAttributes/builtin/ProcessBeanAttributesObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processBeanAttributes/builtin/ProcessBeanAttributesObserver.java
@@ -16,42 +16,53 @@
  */
 package org.jboss.cdi.tck.tests.extensions.lifecycle.processBeanAttributes.builtin;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import jakarta.enterprise.context.Conversation;
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.Extension;
 import jakarta.enterprise.inject.spi.ProcessBeanAttributes;
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class ProcessBeanAttributesObserver implements Extension {
 
     private List<ProcessBeanAttributes<?>> observedBeanAttributes = new ArrayList<ProcessBeanAttributes<?>>();
 
     public void observeHttpServletRequestBeanAttributes(@Observes ProcessBeanAttributes<HttpServletRequest> event) {
-        observedBeanAttributes.add(event);
+        if (event.getBeanAttributes().getQualifiers().contains(Default.Literal.INSTANCE)) {
+            observedBeanAttributes.add(event);
+        }
     }
 
     @SuppressWarnings("rawtypes")
     public void observeEventBeanAttributes(@Observes ProcessBeanAttributes<Event> event) {
-        observedBeanAttributes.add(event);
+        if (event.getBeanAttributes().getQualifiers().contains(Default.Literal.INSTANCE)) {
+            observedBeanAttributes.add(event);
+        }
     }
 
     @SuppressWarnings("rawtypes")
     public void observeInstanceBeanAttributes(@Observes ProcessBeanAttributes<Instance> event) {
-        observedBeanAttributes.add(event);
+        if (event.getBeanAttributes().getQualifiers().contains(Default.Literal.INSTANCE)) {
+            observedBeanAttributes.add(event);
+        }
     }
 
     public void observeConversationBeanAttributes(@Observes ProcessBeanAttributes<Conversation> event) {
-        observedBeanAttributes.add(event);
+        if (event.getBeanAttributes().getQualifiers().contains(Default.Literal.INSTANCE)) {
+            observedBeanAttributes.add(event);
+        }
     }
 
     public void observeBeanManagerBeanAttributes(@Observes ProcessBeanAttributes<BeanManager> event) {
-        observedBeanAttributes.add(event);
+        if (event.getBeanAttributes().getQualifiers().contains(Default.Literal.INSTANCE)) {
+            observedBeanAttributes.add(event);
+        }
     }
 
     public List<ProcessBeanAttributes<?>> getObservedBeanAttributes() {


### PR DESCRIPTION
Fixes https://github.com/jakartaee/cdi-tck/issues/474
Details are in the linked issue. Note that all built-in beans by definition have to have `@Default` qualifier.