### PR TITLE
Change main branch to 4.1 version

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>jakarta.enterprise</groupId>
 		<artifactId>cdi-tck-parent</artifactId>
-		<version>4.0.11-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>cdi-tck-api</artifactId>

--- a/dist-build/libs/pom.xml
+++ b/dist-build/libs/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>jakarta.enterprise</groupId>
         <artifactId>cdi-tck-parent</artifactId>
-        <version>4.0.11-SNAPSHOT</version>
+        <version>4.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/dist-build/pom.xml
+++ b/dist-build/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>jakarta.enterprise</groupId>
       <artifactId>cdi-tck-parent</artifactId>
-      <version>4.0.11-SNAPSHOT</version>
+      <version>4.1.0-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
 

--- a/dist-build/porting-package/pom.xml
+++ b/dist-build/porting-package/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>jakarta.enterprise</groupId>
         <artifactId>cdi-tck-parent</artifactId>
-        <version>4.0.11-SNAPSHOT</version>
+        <version>4.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/doc/reference/pom.xml
+++ b/doc/reference/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>jakarta.enterprise</groupId>
         <artifactId>cdi-tck-parent</artifactId>
-        <version>4.0.11-SNAPSHOT</version>
+        <version>4.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/ext-lib/pom.xml
+++ b/ext-lib/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cdi-tck-parent</artifactId>
         <groupId>jakarta.enterprise</groupId>
-        <version>4.0.11-SNAPSHOT</version>
+        <version>4.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>cdi-tck-ext-lib</artifactId>
     <name>CDI TCK Installed Library - test bean archive</name>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cdi-tck-parent</artifactId>
         <groupId>jakarta.enterprise</groupId>
-        <version>4.0.11-SNAPSHOT</version>
+        <version>4.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cdi-tck-core-impl</artifactId>

--- a/lang-model/pom.xml
+++ b/lang-model/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cdi-tck-parent</artifactId>
         <groupId>jakarta.enterprise</groupId>
-        <version>4.0.11-SNAPSHOT</version>
+        <version>4.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cdi-tck-lang-model</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>jakarta.enterprise</groupId>
     <artifactId>cdi-tck-parent</artifactId>
     <packaging>pom</packaging>
-    <version>4.0.11-SNAPSHOT</version>
+    <version>4.1.0-SNAPSHOT</version>
     <name>Jakarta CDI TCK</name>
 
     <parent>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cdi-tck-parent</artifactId>
         <groupId>jakarta.enterprise</groupId>
-        <version>4.0.11-SNAPSHOT</version>
+        <version>4.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cdi-tck-web-impl</artifactId>


### PR DESCRIPTION
As per discussion in https://github.com/jakartaee/cdi-tck/pull/477#issuecomment-1632335189, this changes the version of main branch to 4.1
I've also created a 4.0 branch should we need further fixes there - https://github.com/jakartaee/cdi-tck/tree/4.0

~~I'll do the same for CDI repo and once merged, I think we should let people know via mailing list.~~
Nevermind, CDI repo is already on 4.1, I forgot :)