### PR TITLE
Add tests for InvocationContext.getInterceptorBindings()

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/AroundConstructBinding1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/AroundConstructBinding1.java
@@ -1,21 +1,22 @@
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.interceptor.InterceptorBinding;
+
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import jakarta.enterprise.util.AnnotationLiteral;
-import jakarta.interceptor.InterceptorBinding;
-
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @InterceptorBinding
 @Inherited
-@Target({ TYPE })
+@Target({ TYPE, METHOD, CONSTRUCTOR })
 @Retention(RUNTIME)
-public @interface SimplePCBinding {
-    class Literal extends AnnotationLiteral<SimplePCBinding> implements SimplePCBinding {
+public @interface AroundConstructBinding1 {
+    class Literal extends AnnotationLiteral<AroundConstructBinding1> implements AroundConstructBinding1 {
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/AroundConstructBinding2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/AroundConstructBinding2.java
@@ -1,21 +1,22 @@
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.interceptor.InterceptorBinding;
+
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import jakarta.enterprise.util.AnnotationLiteral;
-import jakarta.interceptor.InterceptorBinding;
-
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @InterceptorBinding
 @Inherited
-@Target({ TYPE })
+@Target({ TYPE, METHOD, CONSTRUCTOR })
 @Retention(RUNTIME)
-public @interface SimplePCBinding {
-    class Literal extends AnnotationLiteral<SimplePCBinding> implements SimplePCBinding {
+public @interface AroundConstructBinding2 {
+    class Literal extends AnnotationLiteral<AroundConstructBinding2> implements AroundConstructBinding2 {
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/AroundConstructInterceptor1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/AroundConstructInterceptor1.java
@@ -1,0 +1,26 @@
+package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.AroundConstruct;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+@Interceptor
+@AroundConstructBinding1
+@Priority(100)
+public class AroundConstructInterceptor1 {
+    private static Set<Annotation> allBindings;
+
+    @AroundConstruct
+    public Object intercept(InvocationContext ctx) throws Exception {
+        allBindings = ctx.getInterceptorBindings();
+        return ctx.proceed();
+    }
+
+    public static Set<Annotation> getAllBindings() {
+        return allBindings;
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/AroundConstructInterceptor2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/AroundConstructInterceptor2.java
@@ -1,0 +1,26 @@
+package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.AroundConstruct;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+@Interceptor
+@AroundConstructBinding2
+@Priority(200)
+public class AroundConstructInterceptor2 {
+    private static Set<Annotation> allBindings;
+
+    @AroundConstruct
+    public Object intercept(InvocationContext ctx) throws Exception {
+        allBindings = ctx.getInterceptorBindings();
+        return ctx.proceed();
+    }
+
+    public static Set<Annotation> getAllBindings() {
+        return allBindings;
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding11.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding11.java
@@ -1,11 +1,11 @@
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.interceptor.InterceptorBinding;
+
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-
-import jakarta.enterprise.util.AnnotationLiteral;
-import jakarta.interceptor.InterceptorBinding;
 
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
@@ -13,9 +13,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @InterceptorBinding
 @Inherited
-@Target({ TYPE })
+@Target({ TYPE, METHOD })
 @Retention(RUNTIME)
-public @interface SimplePCBinding {
-    class Literal extends AnnotationLiteral<SimplePCBinding> implements SimplePCBinding {
+public @interface Binding11 {
+    class Literal extends AnnotationLiteral<Binding11> implements Binding11 {
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding12.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding12.java
@@ -1,11 +1,11 @@
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.interceptor.InterceptorBinding;
+
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-
-import jakarta.enterprise.util.AnnotationLiteral;
-import jakarta.interceptor.InterceptorBinding;
 
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
@@ -13,9 +13,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @InterceptorBinding
 @Inherited
-@Target({ TYPE })
+@Target({ TYPE, METHOD })
 @Retention(RUNTIME)
-public @interface SimplePCBinding {
-    class Literal extends AnnotationLiteral<SimplePCBinding> implements SimplePCBinding {
+public @interface Binding12 {
+    class Literal extends AnnotationLiteral<Binding12> implements Binding12 {
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding13.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding13.java
@@ -1,0 +1,33 @@
+package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.interceptor.InterceptorBinding;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@InterceptorBinding
+@Inherited
+@Target({ TYPE, METHOD })
+@Retention(RUNTIME)
+public @interface Binding13 {
+    String value();
+
+    class Literal extends AnnotationLiteral<Binding13> implements Binding13 {
+        private final String value;
+
+        public Literal(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String value() {
+            return value;
+        }
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding14.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding14.java
@@ -1,0 +1,35 @@
+package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.enterprise.util.Nonbinding;
+import jakarta.interceptor.InterceptorBinding;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@InterceptorBinding
+@Inherited
+@Target({ TYPE, METHOD })
+@Retention(RUNTIME)
+public @interface Binding14 {
+    @Nonbinding
+    String value();
+
+    class Literal extends AnnotationLiteral<Binding14> implements Binding14 {
+        private final String value;
+
+        public Literal(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String value() {
+            return value;
+        }
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor11.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor11.java
@@ -1,0 +1,16 @@
+package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+@Interceptor
+@Binding11
+@Priority(1100)
+public class Interceptor11 {
+    @AroundInvoke
+    public Object intercept(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor12.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor12.java
@@ -1,0 +1,52 @@
+package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+@Interceptor
+@Binding12
+@Priority(1200)
+public class Interceptor12 {
+    private static Set<Annotation> allBindings;
+
+    private static Set<Binding12> binding12s; // must be non-empty
+    private static Binding12 binding12; // must be non-null
+
+    private static Set<Binding5> binding5s; // must be empty
+    private static Binding6 binding6; // must be null
+
+    @AroundInvoke
+    public Object intercept(InvocationContext ctx) throws Exception {
+        allBindings = ctx.getInterceptorBindings();
+        binding12s = ctx.getInterceptorBindings(Binding12.class);
+        binding12 = ctx.getInterceptorBinding(Binding12.class);
+        binding5s = ctx.getInterceptorBindings(Binding5.class);
+        binding6 = ctx.getInterceptorBinding(Binding6.class);
+        return ctx.proceed();
+    }
+
+    public static Set<Annotation> getAllBindings() {
+        return allBindings;
+    }
+
+    public static Set<Binding12> getBinding12s() {
+        return binding12s;
+    }
+
+    public static Binding12 getBinding12() {
+        return binding12;
+    }
+
+    public static Set<Binding5> getBinding5s() {
+        return binding5s;
+    }
+
+    public static Binding6 getBinding6() {
+        return binding6;
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor13.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor13.java
@@ -1,0 +1,16 @@
+package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+@Interceptor
+@Binding13("ok")
+@Priority(1300)
+public class Interceptor13 {
+    @AroundInvoke
+    public Object intercept(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor14.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor14.java
@@ -1,0 +1,16 @@
+package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+@Interceptor
+@Binding14("")
+@Priority(1400)
+public class Interceptor14 {
+    @AroundInvoke
+    public Object intercept(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/InvocationContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/InvocationContextTest.java
@@ -20,6 +20,7 @@ import static org.jboss.cdi.tck.interceptors.InterceptorsSections.CONSTRUCTOR_AN
 import static org.jboss.cdi.tck.interceptors.InterceptorsSections.INVOCATIONCONTEXT;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
@@ -31,13 +32,15 @@ import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
+import java.util.Set;
+
 /**
  * Tests for the InvocationContext implementation
  *
  * @author Jozef Hartinger
  *
  */
-@SpecVersion(spec = "interceptors", version = "1.2")
+@SpecVersion(spec = "interceptors", version = "2.2")
 public class InvocationContextTest extends AbstractTest {
 
     @Deployment
@@ -121,5 +124,25 @@ public class InvocationContextTest extends AbstractTest {
     public void testBusinessMethodNotCalledWithoutProceedInvocation() {
         assertEquals(getContextualReference(SimpleBean.class).echo("foo"), "foo");
         assertFalse(SimpleBean.isEchoCalled());
+    }
+
+    @Test
+    @SpecAssertion(section = INVOCATIONCONTEXT, id = "n")
+    @SpecAssertion(section = INVOCATIONCONTEXT, id = "o")
+    public void testGetInterceptorBindings() {
+        assertTrue(getContextualReference(SimpleBean.class).bindings());
+        assertEquals(AroundConstructInterceptor1.getAllBindings(), Set.of(new SimplePCBinding.Literal(),
+                new PseudoBinding.Literal(), new AroundConstructBinding1.Literal(),
+                new AroundConstructBinding2.Literal()));
+        assertEquals(AroundConstructInterceptor1.getAllBindings(), AroundConstructInterceptor2.getAllBindings());
+        assertEquals(PostConstructInterceptor.getAllBindings(), Set.of(new SimplePCBinding.Literal(),
+                new PseudoBinding.Literal(), new AroundConstructBinding1.Literal()));
+        assertEquals(Interceptor12.getAllBindings(), Set.of(new SimplePCBinding.Literal(), new PseudoBinding.Literal(),
+                new AroundConstructBinding1.Literal(), new Binding11.Literal(), new Binding12.Literal(),
+                new Binding13.Literal("ko"), new Binding14.Literal("foobar")));
+        assertEquals(Interceptor12.getBinding12s(), Set.of(new Binding12.Literal()));
+        assertEquals(Interceptor12.getBinding12(), new Binding12.Literal());
+        assertEquals(Interceptor12.getBinding5s(), Set.of());
+        assertNull(Interceptor12.getBinding6());
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/PostConstructInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/PostConstructInterceptor.java
@@ -21,12 +21,17 @@ import jakarta.annotation.Priority;
 import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
 
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
 @Interceptor
 @SimplePCBinding
 @Priority(100)
 public class PostConstructInterceptor {
     private static boolean getMethodReturnsNull = false;
     private static boolean ctxProceedReturnsNull = false;
+
+    private static Set<Annotation> allBindings = null;
 
     @PostConstruct
     public void postConstruct(InvocationContext ctx) {
@@ -35,6 +40,8 @@ public class PostConstructInterceptor {
             ctxProceedReturnsNull = ctx.proceed() == null;
         } catch (Exception e) {
         }
+
+        allBindings = ctx.getInterceptorBindings();
     }
 
     public static boolean isGetMethodReturnsNull() {
@@ -43,5 +50,9 @@ public class PostConstructInterceptor {
 
     public static boolean isCtxProceedReturnsNull() {
         return ctxProceedReturnsNull;
+    }
+
+    public static Set<Annotation> getAllBindings() {
+        return allBindings;
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/PseudoBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/PseudoBinding.java
@@ -1,21 +1,25 @@
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.enterprise.util.Nonbinding;
+import jakarta.interceptor.InterceptorBinding;
+
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-
-import jakarta.enterprise.util.AnnotationLiteral;
-import jakarta.interceptor.InterceptorBinding;
 
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+/**
+ * This is an interceptor binding, but there is no matching interceptor.
+ */
 @InterceptorBinding
 @Inherited
-@Target({ TYPE })
+@Target({ TYPE, METHOD })
 @Retention(RUNTIME)
-public @interface SimplePCBinding {
-    class Literal extends AnnotationLiteral<SimplePCBinding> implements SimplePCBinding {
+public @interface PseudoBinding {
+    class Literal extends AnnotationLiteral<PseudoBinding> implements PseudoBinding {
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SimpleBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SimpleBean.java
@@ -19,10 +19,16 @@ package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 import jakarta.enterprise.context.Dependent;
 
 @SimplePCBinding
+@PseudoBinding
+@AroundConstructBinding1
 @Dependent
 class SimpleBean {
     private int id = 0;
     private static boolean echoCalled = false;
+
+    @AroundConstructBinding2
+    public SimpleBean() {
+    }
 
     @Binding1
     public int getId() {
@@ -70,6 +76,14 @@ class SimpleBean {
     public String echo(String s) {
         echoCalled = true;
         return s;
+    }
+
+    @Binding11
+    @Binding12
+    @Binding13("ko") // does not associate `Interceptor13` with this bean due to different annotation member
+    @Binding14("foobar")
+    public boolean bindings() {
+        return true;
     }
 
     public static boolean isEchoCalled() {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/Dog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/Dog.java
@@ -1,0 +1,13 @@
+package org.jboss.cdi.tck.tests.full.interceptors.contract.invocationContext;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.interceptor.ExcludeClassInterceptors;
+import jakarta.interceptor.Interceptors;
+
+@Interceptors(DogInterceptor.class)
+@Dependent
+class Dog {
+    public String foo() {
+        return "bar";
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/DogInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/DogInterceptor.java
@@ -1,0 +1,21 @@
+package org.jboss.cdi.tck.tests.full.interceptors.contract.invocationContext;
+
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.InvocationContext;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+public class DogInterceptor {
+    private static Set<Annotation> allBindings;
+
+    @AroundInvoke
+    public Object intercept(InvocationContext ctx) throws Exception {
+        allBindings = ctx.getInterceptorBindings();
+        return "dog: " + ctx.proceed();
+    }
+
+    public static Set<Annotation> getAllBindings() {
+        return allBindings;
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/Fish.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/Fish.java
@@ -1,0 +1,12 @@
+package org.jboss.cdi.tck.tests.full.interceptors.contract.invocationContext;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.interceptor.Interceptors;
+
+@Dependent
+class Fish {
+    @Interceptors(FishInterceptor.class)
+    public String foo() {
+        return "bar";
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/FishInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/FishInterceptor.java
@@ -1,0 +1,21 @@
+package org.jboss.cdi.tck.tests.full.interceptors.contract.invocationContext;
+
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.InvocationContext;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+public class FishInterceptor {
+    private static Set<Annotation> allBindings;
+
+    @AroundInvoke
+    public Object intercept(InvocationContext ctx) throws Exception {
+        allBindings = ctx.getInterceptorBindings();
+        return "fish: " + ctx.proceed();
+    }
+
+    public static Set<Annotation> getAllBindings() {
+        return allBindings;
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/InterceptorBindingsWithAtInterceptorsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/InterceptorBindingsWithAtInterceptorsTest.java
@@ -1,0 +1,38 @@
+package org.jboss.cdi.tck.tests.full.interceptors.contract.invocationContext;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+import static org.jboss.cdi.tck.TestGroups.CDI_FULL;
+import static org.jboss.cdi.tck.interceptors.InterceptorsSections.INVOCATIONCONTEXT;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+@SpecVersion(spec = "interceptors", version = "2.2")
+@Test(groups = CDI_FULL)
+public class InterceptorBindingsWithAtInterceptorsTest extends AbstractTest {
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder().withTestClassPackage(InterceptorBindingsWithAtInterceptorsTest.class).build();
+    }
+
+    @Test
+    @SpecAssertion(section = INVOCATIONCONTEXT, id = "n")
+    public void testInterceptorBindingsEmptyWithAtInterceptors() {
+        Dog dog = getContextualReference(Dog.class);
+        assertEquals(dog.foo(), "dog: bar");
+        assertNotNull(DogInterceptor.getAllBindings());
+        assertTrue(DogInterceptor.getAllBindings().isEmpty());
+
+        Fish fish = getContextualReference(Fish.class);
+        assertEquals(fish.foo(), "fish: bar");
+        assertNotNull(FishInterceptor.getAllBindings());
+        assertTrue(FishInterceptor.getAllBindings().isEmpty());
+    }
+}

--- a/impl/src/main/resources/tck-audit-int.xml
+++ b/impl/src/main/resources/tck-audit-int.xml
@@ -332,6 +332,24 @@
             <note>Unclear meaning of validation.</note>
         </assertion>
 
+        <assertion id="n">
+            <text>
+                The |getInterceptorBindings| method returns the set of interceptor binding
+                annotations for the method or constructor whose invocation is being intercepted.
+                In case there is no target method or target constructor, interceptor binding
+                annotations applied to the target class are returned. All interceptor binding
+                annotations are returned, including interceptor binding annotations that associate
+                interceptors of a different interceptor method type, as well as interceptor
+                binding annotations that associate no interceptor.
+            </text>
+        </assertion>
+
+        <assertion id="o">
+            <text>
+                The |getInterceptorBinding| method returns the single annotation of given type
+                present in the set of interceptor bindings returned by |getInterceptorBindings()|.
+            </text>
+        </assertion>
     </section>
 
     <section id="exceptions" title="Exceptions" level="2">

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <maven.compiler.release>11</maven.compiler.release>
         <!-- Jakarta EE APIs Core -->
         <annotations.api.version>2.1.0</annotations.api.version>
-        <interceptors.api.version>2.1.0</interceptors.api.version>
+        <interceptors.api.version>2.2.0-RC1</interceptors.api.version>
         <atinject.api.version>2.0.1</atinject.api.version>
         <el.api.version>5.0.0</el.api.version>
 

--- a/web/src/main/resources/tck-audit-int.xml
+++ b/web/src/main/resources/tck-audit-int.xml
@@ -332,6 +332,24 @@
             <note>Unclear meaning of validation.</note>
         </assertion>
 
+        <assertion id="n">
+            <text>
+                The |getInterceptorBindings| method returns the set of interceptor binding
+                annotations for the method or constructor whose invocation is being intercepted.
+                In case there is no target method or target constructor, interceptor binding
+                annotations applied to the target class are returned. All interceptor binding
+                annotations are returned, including interceptor binding annotations that associate
+                interceptors of a different interceptor method type, as well as interceptor
+                binding annotations that associate no interceptor.
+            </text>
+        </assertion>
+
+        <assertion id="o">
+            <text>
+                The |getInterceptorBinding| method returns the single annotation of given type
+                present in the set of interceptor bindings returned by |getInterceptorBindings()|.
+            </text>
+        </assertion>
     </section>
 
     <section id="exceptions" title="Exceptions" level="2">


### PR DESCRIPTION
TCK tests for https://github.com/jakartaee/interceptors/pull/99

Draft because there's a temporary profile to enable using Jakarta staging repository. Once Interceptors 2.2.0-RC1 hits Maven Central, I'll remove that and this PR will be ready.