### PR TITLE
remove obsolete TCK test exclusion

### DIFF
--- a/impl/src/main/resources/tck-tests.xml
+++ b/impl/src/main/resources/tck-tests.xml
@@ -23,14 +23,6 @@
         </packages>
 
         <classes>
-            <!-- https://github.com/jakartaee/cdi-tck/issues/431 -->
-            <!-- This test is disabled in 4.0 not to break existing impls and should be re-enabled for 4.1 release -->
-            <class name="org.jboss.cdi.tck.tests.full.extensions.lifecycle.bbd.broken.passivatingScope.AddingPassivatingScopeTest">
-                <methods>
-                    <exclude name=".*"/>
-                </methods>
-            </class>
-
             <!-- https://github.com/jakartaee/cdi-tck/issues/440 -->
             <class name="org.jboss.cdi.tck.tests.full.extensions.lifecycle.processBeanAttributes.specialization.VetoTest">
                 <methods>


### PR DESCRIPTION
We previously [1] fixed a TCK bug, but that fix was in fact a breaking change. To avoid ripple effects, we later [2] added that test to the canonical exclusion list with plan to remove the exclusion in the next CDI TCK version. That's what this commit does.

[1] https://github.com/jakartaee/cdi-tck/commit/c4eb66e0822b36ee2d585c56c5b016b6944ade65
[2] https://github.com/jakartaee/cdi-tck/commit/5ba2f72048cbe9abcf874d43fd3d1d1b27d5f2e0