### PR TITLE
Specify event that triggers exception

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/runtimeException/ObserverExceptionRethrownTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/runtimeException/ObserverExceptionRethrownTest.java
@@ -44,7 +44,7 @@ public class ObserverExceptionRethrownTest extends AbstractTest {
     @Test(expectedExceptions = { TeaCupPomeranian.OversizedException.class })
     @SpecAssertion(section = OBSERVER_NOTIFICATION, id = "cd")
     public void testNonTransactionalObserverThrowsNonCheckedExceptionIsRethrown() {
-        getCurrentManager().getEvent().select(String.class).fire("string event");
+        getCurrentManager().getEvent().select(String.class).fire(TeaCupPomeranian.TRIGGER);
     }
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/runtimeException/ObserverExceptionRethrownTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/runtimeException/ObserverExceptionRethrownTest.java
@@ -22,6 +22,7 @@ import static org.jboss.cdi.tck.cdi.Sections.OBSERVER_NOTIFICATION;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.cdi.tck.tests.event.observer.runtimeException.TeaCupPomeranian.Trigger;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
@@ -44,7 +45,7 @@ public class ObserverExceptionRethrownTest extends AbstractTest {
     @Test(expectedExceptions = { TeaCupPomeranian.OversizedException.class })
     @SpecAssertion(section = OBSERVER_NOTIFICATION, id = "cd")
     public void testNonTransactionalObserverThrowsNonCheckedExceptionIsRethrown() {
-        getCurrentManager().getEvent().select(String.class).fire(TeaCupPomeranian.TRIGGER);
+        getCurrentManager().getEvent().select(Trigger.class).fire(new Trigger());
     }
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/runtimeException/TeaCupPomeranian.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/runtimeException/TeaCupPomeranian.java
@@ -22,16 +22,14 @@ import jakarta.enterprise.event.Observes;
 @Dependent
 public class TeaCupPomeranian {
 
-    static final String TRIGGER = "string event";
-    
     public static class OversizedException extends RuntimeException {
         private static final long serialVersionUID = 1L;
     }
 
-    public void observeSimpleEvent(@Observes String someEvent) {
-        if (TRIGGER.equals(someEvent)) {
-            throw new OversizedException();
-        }
+    static class Trigger {};
+
+    public void observeSimpleEvent(@Observes Trigger someEvent) {
+        throw new OversizedException();
     }
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/runtimeException/TeaCupPomeranian.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/runtimeException/TeaCupPomeranian.java
@@ -22,12 +22,16 @@ import jakarta.enterprise.event.Observes;
 @Dependent
 public class TeaCupPomeranian {
 
+    static final String TRIGGER = "string event";
+    
     public static class OversizedException extends RuntimeException {
         private static final long serialVersionUID = 1L;
     }
 
     public void observeSimpleEvent(@Observes String someEvent) {
-        throw new OversizedException();
+        if (TRIGGER.equals(someEvent)) {
+            throw new OversizedException();
+        }
     }
 
 }


### PR DESCRIPTION
`ObserverExceptionRethrownTest#testNonTransactionalObserverThrowsNonCheckedExceptionIsRethrown` verifies that one exception happens when firing one event.

 In the case of Helidon, this exception is thrown on deployment `ObserverExceptionRethrownTest#createTestArchive` because Helidon container fires 2 events on deployment. One to notify when beans are going to be deployed, and other when beans are deployed.

Proposed solution: `TeaCupPomeranian` will evaluate the event content, to throw the exception only when we want to throw it.