### PR TITLE
Update CDI API to 4.1.0.Alpha1

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/broken/event/ContainerLifecycleEvents.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/broken/event/ContainerLifecycleEvents.java
@@ -57,6 +57,8 @@ import jakarta.enterprise.inject.spi.configurator.BeanConfigurator;
 import jakarta.enterprise.inject.spi.configurator.InjectionPointConfigurator;
 import jakarta.enterprise.inject.spi.configurator.ObserverMethodConfigurator;
 import jakarta.enterprise.inject.spi.configurator.ProducerConfigurator;
+import jakarta.enterprise.invoke.Invoker;
+import jakarta.enterprise.invoke.InvokerBuilder;
 
 public class ContainerLifecycleEvents {
 
@@ -328,6 +330,11 @@ public class ContainerLifecycleEvents {
 
         @Override
         public AnnotatedType<Object> getAnnotatedBeanClass() {
+            return null;
+        }
+
+        @Override
+        public InvokerBuilder<Invoker<Object, ?>> createInvoker(AnnotatedMethod<? super Object> annotatedMethod) {
             return null;
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
 
     <properties>
         <!-- CDI API -->
-        <cdi.api.version>4.0.1</cdi.api.version>
+        <cdi.api.version>4.1.0.Alpha1</cdi.api.version>
         <maven.compiler.release>11</maven.compiler.release>
         <!-- Jakarta EE APIs Core -->
         <annotations.api.version>2.1.0</annotations.api.version>


### PR DESCRIPTION
Updates CDI API to freshly released Alpha1 for 4.1 version.