### PR TITLE
Add missing literal to BeanManagerTest

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/BeanManagerTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/BeanManagerTest.java
@@ -84,7 +84,7 @@ public class BeanManagerTest extends AbstractTest {
     @Deployment
     public static WebArchive createTestArchive() {
         return new WebArchiveBuilder().withTestClassPackage(BeanManagerTest.class)
-                .withClasses(RetentionLiteral.class, TargetLiteral.class, StereotypeLiteral.class)
+                .withClasses(RetentionLiteral.class, TargetLiteral.class, StereotypeLiteral.class, InheritedLiteral.class)
                 .withExtensions(AfterBeanDiscoveryObserver.class).build();
     }
 


### PR DESCRIPTION
Follows up on https://github.com/jakartaee/cdi-tck/pull/494
Linked to isse https://github.com/jakartaee/cdi-tck/issues/493

The previous merge was a bit too fast, I didn't manage to run all WFLY tests to spot this one as well :)
With this change, I am getting a pass:

```
[INFO] Results:
[INFO] 
[INFO] Tests run: 1834, Failures: 0, Errors: 0, Skipped: 0

```