### PR TITLE
Relax the scope requirement for public fields

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/SimpleBeanDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/SimpleBeanDefinitionTest.java
@@ -118,4 +118,10 @@ public class SimpleBeanDefinitionTest extends AbstractTest {
         Assert.assertEquals(getContextualReference(Tiger.class).name, "pete");
     }
 
+    @Test
+    @SpecAssertion(section = MANAGED_BEANS, id = "fa")
+    public void testSingletonScopedBeanCanHaveNonStaticPublicField() throws Exception {
+        Assert.assertEquals(getContextualReference(SnowTiger.class).name, "martin");
+    }
+
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/SnowTiger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/SnowTiger.java
@@ -1,0 +1,11 @@
+package org.jboss.cdi.tck.tests.implementation.simple.definition;
+
+import jakarta.inject.Singleton;
+
+@White
+@Singleton
+public class SnowTiger {
+
+    public String name = "martin";
+
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/White.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/White.java
@@ -1,0 +1,14 @@
+package org.jboss.cdi.tck.tests.implementation.simple.definition;
+
+import jakarta.enterprise.inject.Stereotype;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Stereotype
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface White {
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/normalScopedWithPublicField/Leopard_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/normalScopedWithPublicField/Leopard_Broken.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.implementation.simple.definition.dependentWithPublicField;
+package org.jboss.cdi.tck.tests.implementation.simple.definition.normalScopedWithPublicField;
 
 import jakarta.enterprise.context.RequestScoped;
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/normalScopedWithPublicField/NormalScopedWithPublicFieldTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/normalScopedWithPublicField/NormalScopedWithPublicFieldTest.java
@@ -14,12 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.implementation.simple.definition.nonDependentWithPublicStaticField;
+package org.jboss.cdi.tck.tests.implementation.simple.definition.normalScopedWithPublicField;
 
+import static org.jboss.cdi.tck.cdi.Sections.EXCEPTIONS;
 import static org.jboss.cdi.tck.cdi.Sections.MANAGED_BEANS;
-import static org.testng.Assert.assertEquals;
+
+import jakarta.enterprise.inject.spi.DefinitionException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -29,17 +32,17 @@ import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
 @SpecVersion(spec = "cdi", version = "2.0")
-public class NonDependentWithPublicStaticFieldTest extends AbstractTest {
+public class NormalScopedWithPublicFieldTest extends AbstractTest {
 
+    @ShouldThrowException(DefinitionException.class)
     @Deployment
     public static WebArchive createTestArchive() {
-        return new WebArchiveBuilder().withTestClassPackage(NonDependentWithPublicStaticFieldTest.class).build();
+        return new WebArchiveBuilder().withTestClassPackage(NormalScopedWithPublicFieldTest.class).build();
     }
 
     @Test
-    @SpecAssertions({ @SpecAssertion(section = MANAGED_BEANS, id = "fb") })
-    public void testNonDependentScopedBeanCanHavePublicStaticField() {
-        assertEquals(Leopard.NAME, "john");
+    @SpecAssertions({ @SpecAssertion(section = MANAGED_BEANS, id = "fc"), @SpecAssertion(section = EXCEPTIONS, id = "ba") })
+    public void testNormalScopedBeanCanNotHavePublicField() {
     }
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/normalScopedWithPublicStaticField/Leopard.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/normalScopedWithPublicStaticField/Leopard.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.implementation.simple.definition.nonDependentWithPublicStaticField;
+package org.jboss.cdi.tck.tests.implementation.simple.definition.normalScopedWithPublicStaticField;
 
 import jakarta.enterprise.context.RequestScoped;
 

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/normalScopedWithPublicStaticField/NormalScopedWithPublicStaticFieldTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/normalScopedWithPublicStaticField/NormalScopedWithPublicStaticFieldTest.java
@@ -14,15 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.cdi.tck.tests.implementation.simple.definition.dependentWithPublicField;
+package org.jboss.cdi.tck.tests.implementation.simple.definition.normalScopedWithPublicStaticField;
 
-import static org.jboss.cdi.tck.cdi.Sections.EXCEPTIONS;
 import static org.jboss.cdi.tck.cdi.Sections.MANAGED_BEANS;
-
-import jakarta.enterprise.inject.spi.DefinitionException;
+import static org.testng.Assert.assertEquals;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -32,17 +29,17 @@ import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
 @SpecVersion(spec = "cdi", version = "2.0")
-public class DependentWithPublicFieldTest extends AbstractTest {
+public class NormalScopedWithPublicStaticFieldTest extends AbstractTest {
 
-    @ShouldThrowException(DefinitionException.class)
     @Deployment
     public static WebArchive createTestArchive() {
-        return new WebArchiveBuilder().withTestClassPackage(DependentWithPublicFieldTest.class).build();
+        return new WebArchiveBuilder().withTestClassPackage(NormalScopedWithPublicStaticFieldTest.class).build();
     }
 
     @Test
-    @SpecAssertions({ @SpecAssertion(section = MANAGED_BEANS, id = "fc"), @SpecAssertion(section = EXCEPTIONS, id = "ba") })
-    public void testNonDependentScopedBeanCanNotHavePublicField() {
+    @SpecAssertions({ @SpecAssertion(section = MANAGED_BEANS, id = "fb") })
+    public void testNormalScopedBeanCanHavePublicStaticField() {
+        assertEquals(Leopard.NAME, "john");
     }
 
 }

--- a/impl/src/main/resources/tck-audit-cdi.xml
+++ b/impl/src/main/resources/tck-audit-cdi.xml
@@ -851,19 +851,17 @@
         </assertion>
 
         <group>
-            <text>If a managed bean has a non-static public field, it must have scope |@Dependent|. If a managed bean with a non-static public field declares
-                any scope other than |@Dependent|, the container automatically detects the problem and treats it as a definition error.
+            <text>If a managed bean has a non-static public field, its scope must be a pseudo-scope.
+                If a managed bean with a non-static public field declares a normal scope, the container automatically detects the problem and treats it as a definition error.
             </text>
             <assertion id="fa">
-                <text>Check a dependent scoped bean with a public field.</text>
+                <text>Check a pseudo-scoped bean with a public field.</text>
             </assertion>
             <assertion id="fb">
-                <text>Check a managed bean with a static public field which declares any scope other than |@Dependent|.</text>
+                <text>Check a managed bean with a static public field which declares a normal scope.</text>
             </assertion>
             <assertion id="fc">
-                <text>If a managed bean with a non-static public field declares any scope other than |@Dependent|, the container automatically detects the
-                    problem and treats it as a definition error.
-                </text>
+                <text>Check a managed bean with a non-static public field which declares a normal scope.</text>
             </assertion>
         </group>
 

--- a/web/src/main/resources/tck-audit-cdi.xml
+++ b/web/src/main/resources/tck-audit-cdi.xml
@@ -837,19 +837,17 @@
         </assertion>
 
         <group>
-            <text>If a managed bean has a non-static public field, it must have scope |@Dependent|. If a managed bean with a non-static public field declares
-                any scope other than |@Dependent|, the container automatically detects the problem and treats it as a definition error.
+            <text>If a managed bean has a non-static public field, its scope must be a pseudo-scope.
+                If a managed bean with a non-static public field declares a normal scope, the container automatically detects the problem and treats it as a definition error.
             </text>
             <assertion id="fa">
-                <text>Check a dependent scoped bean with a public field.</text>
+                <text>Check a pseudo-scoped bean with a public field.</text>
             </assertion>
             <assertion id="fb">
-                <text>Check a managed bean with a static public field which declares any scope other than |@Dependent|.</text>
+                <text>Check a managed bean with a static public field which declares a normal scope.</text>
             </assertion>
             <assertion id="fc">
-                <text>If a managed bean with a non-static public field declares any scope other than |@Dependent|, the container automatically detects the
-                    problem and treats it as a definition error.
-                </text>
+                <text>Check a managed bean with a non-static public field which declares a normal scope.</text>
             </assertion>
         </group>
 


### PR DESCRIPTION
This is a TCK counterpart to the [specification change](https://github.com/jakartaee/cdi/pull/698) that allows all pseudo-scoped beans to have public fields. It updates the text in `tck-audit-cdi.xml` files, fixes naming in the relevant tests and adds a test that a `@Singleton` bean can have a public field.