### PR TITLE
fix InvocationContextTest and InterceptorBindingInheritanceTest

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/InvocationContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/InvocationContextTest.java
@@ -56,7 +56,7 @@ public class InvocationContextTest extends AbstractTest {
         SimpleBean instance = getContextualReference(SimpleBean.class);
         instance.setId(10);
         assertEquals(instance.getId(), 10);
-        assertSame(Interceptor1.getTarget(), instance);
+        assertEquals(Interceptor1.getTarget().getId(), 10);
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/InterceptorBindingInheritanceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/InterceptorBindingInheritanceTest.java
@@ -52,48 +52,54 @@ public class InterceptorBindingInheritanceTest extends AbstractTest {
     @Test(dataProvider = ARQUILLIAN_DATA_PROVIDER)
     @SpecAssertions({ @SpecAssertion(section = TYPE_LEVEL_INHERITANCE, id = "ad"), @SpecAssertion(section = TYPE_LEVEL_INHERITANCE, id = "ada") })
     public void testInterceptorBindingDirectlyInheritedFromManagedBean(Larch larch) throws Exception {
+        Plant.clearInspections();
         larch.pong();
-        assertTrue(Plant.inspectedBy(larch, squirrel));
-        assertFalse(Plant.inspectedBy(larch, woodpecker));
+        assertTrue(Plant.inspectedBy(squirrel));
+        assertFalse(Plant.inspectedBy(woodpecker));
     }
 
     @Test(dataProvider = ARQUILLIAN_DATA_PROVIDER)
     @SpecAssertions({ @SpecAssertion(section = TYPE_LEVEL_INHERITANCE, id = "aj"), @SpecAssertion(section = TYPE_LEVEL_INHERITANCE, id = "aja") })
     public void testInterceptorBindingIndirectlyInheritedFromManagedBean(@European Larch europeanLarch) throws Exception {
+        Plant.clearInspections();
         europeanLarch.pong();
         assertTrue(europeanLarch instanceof EuropeanLarch);
-        assertTrue(Plant.inspectedBy(europeanLarch, squirrel));
-        assertFalse(Plant.inspectedBy(europeanLarch, woodpecker));
+        assertTrue(Plant.inspectedBy(squirrel));
+        assertFalse(Plant.inspectedBy(woodpecker));
     }
 
     @Test(dataProvider = ARQUILLIAN_DATA_PROVIDER)
     @SpecAssertion(section = MEMBER_LEVEL_INHERITANCE, id = "ka")
     public void testMethodInterceptorBindingDirectlyInheritedFromManagedBean(Herb herb) {
+        Plant.clearInspections();
         herb.pong();
-        assertTrue(Plant.inspectedBy(herb, squirrel));
+        assertTrue(Plant.inspectedBy(squirrel));
     }
 
     @Test(dataProvider = ARQUILLIAN_DATA_PROVIDER)
     @SpecAssertion(section = MEMBER_LEVEL_INHERITANCE, id = "kc")
     public void testMethodInterceptorBindingIndirectlyInheritedFromManagedBean(@Culinary Herb thyme) {
+        Plant.clearInspections();
         thyme.pong();
         assertTrue(thyme instanceof Thyme);
-        assertTrue(Plant.inspectedBy(thyme, squirrel));
+        assertTrue(Plant.inspectedBy(squirrel));
     }
 
     @Test(dataProvider = ARQUILLIAN_DATA_PROVIDER)
     @SpecAssertion(section = MEMBER_LEVEL_INHERITANCE, id = "ka")
     public void testMethodInterceptorBindingDirectlyNotInheritedFromManagedBean(Shrub shrub) {
+        Plant.clearInspections();
         shrub.pong();
-        assertFalse(Plant.inspectedBy(shrub, squirrel));
+        assertFalse(Plant.inspectedBy(squirrel));
     }
 
     @Test(dataProvider = ARQUILLIAN_DATA_PROVIDER)
     @SpecAssertion(section = MEMBER_LEVEL_INHERITANCE, id = "kc")
     public void testMethodInterceptorBindingIndirectlyNotInheritedFromManagedBean(@Culinary Shrub rosehip) {
+        Plant.clearInspections();
         rosehip.pong();
         assertTrue(rosehip instanceof Rosehip);
-        assertFalse(Plant.inspectedBy(rosehip, squirrel));
+        assertFalse(Plant.inspectedBy(squirrel));
     }
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/Plant.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/Plant.java
@@ -21,16 +21,18 @@ import java.util.List;
 
 public abstract class Plant implements Ping {
 
-    private List<String> inspections = new ArrayList<String>();
+    private static List<String> inspections = new ArrayList<String>();
 
-    // all beans of type `Plant` are `@Dependent`, so accessing the field is OK
-
-    public static void inspect(Plant plant, String id) {
-        plant.inspections.add(id);
+    public static void clearInspections() {
+        inspections.clear();
     }
 
-    public static boolean inspectedBy(Plant plant, String id) {
-        return plant.inspections.contains(id);
+    public static void inspect(String id) {
+        inspections.add(id);
+    }
+
+    public static boolean inspectedBy(String id) {
+        return inspections.contains(id);
     }
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/SquirrelInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/SquirrelInterceptor.java
@@ -32,7 +32,7 @@ public class SquirrelInterceptor {
         Object target = ctx.getTarget();
 
         if (target instanceof Plant) {
-            Plant.inspect((Plant) target, SquirrelInterceptor.class.getName());
+            Plant.inspect(SquirrelInterceptor.class.getName());
         }
         return ctx.proceed();
     }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/WoodpeckerInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/WoodpeckerInterceptor.java
@@ -32,7 +32,7 @@ public class WoodpeckerInterceptor {
         Object target = ctx.getTarget();
 
         if (target instanceof Plant) {
-            Plant.inspect((Plant) target, WoodpeckerInterceptor.class.getName());
+            Plant.inspect(WoodpeckerInterceptor.class.getName());
         }
         return ctx.proceed();
     }


### PR DESCRIPTION
This is to cater for implementations that implement interception by proxying, in which case the contextual instance of a bean is an interception proxy, while `InvocationContext.getTarget()` returns the proxied object (an "actual" instance of the bean).

Stems from recent discussion in #468