### PR TITLE
Add test coverage for declaring @Priority on producers

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/Alpha.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/Alpha.java
@@ -1,0 +1,14 @@
+package org.jboss.cdi.tck.tests.alternative.selection.priority;
+
+public class Alpha {
+
+    private String s;
+
+    public Alpha(String s) {
+        this.s = s;
+    }
+
+    public String ping() {
+        return s;
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/AltBeanProducingAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/AltBeanProducingAlternative.java
@@ -1,0 +1,26 @@
+package org.jboss.cdi.tck.tests.alternative.selection.priority;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Produces;
+
+@Alternative
+@Priority(1)
+@ApplicationScoped
+public class AltBeanProducingAlternative {
+
+    @Alternative
+    @Priority(20) // should override class-level priority value and hence end up having the highest priority
+    @Produces
+    @ProducedByMethod
+    Beta producer1() {
+        return new Beta(ProducerExplicitPriorityTest.ALT2);
+    }
+
+    @Alternative
+    @Priority(20) // should override class-level priority value and hence end up having the highest priority
+    @Produces
+    @ProducedByField
+    Beta producer2 = new Beta(ProducerExplicitPriorityTest.ALT2);
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/AltBeanProducingPrioritizedNonAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/AltBeanProducingPrioritizedNonAlternative.java
@@ -1,0 +1,24 @@
+package org.jboss.cdi.tck.tests.alternative.selection.priority;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Produces;
+
+@ApplicationScoped
+@Alternative
+@Priority(1)
+public class AltBeanProducingPrioritizedNonAlternative {
+
+    @Priority(20) // should override class-level priority value and hence end up having the highest priority
+    @Produces
+    @ProducedByMethod
+    Delta producer1() {
+        return new Delta(ProducerExplicitPriorityTest.ALT2);
+    }
+
+    @Priority(20) // should override class-level priority value and hence end up having the highest priority
+    @Produces
+    @ProducedByField
+    Delta producer2 = new Delta(ProducerExplicitPriorityTest.ALT2);
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/Beta.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/Beta.java
@@ -1,0 +1,14 @@
+package org.jboss.cdi.tck.tests.alternative.selection.priority;
+
+public class Beta {
+
+    private String s;
+
+    public Beta(String s) {
+        this.s = s;
+    }
+
+    public String ping() {
+        return s;
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/Delta.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/Delta.java
@@ -1,0 +1,14 @@
+package org.jboss.cdi.tck.tests.alternative.selection.priority;
+
+public class Delta {
+
+    private String s;
+
+    public Delta(String s) {
+        this.s = s;
+    }
+
+    public String ping() {
+        return s;
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/Gamma.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/Gamma.java
@@ -1,0 +1,14 @@
+package org.jboss.cdi.tck.tests.alternative.selection.priority;
+
+public class Gamma {
+
+    private String s;
+
+    public Gamma(String s) {
+        this.s = s;
+    }
+
+    public String ping() {
+        return s;
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/NonAltBeanProducingAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/NonAltBeanProducingAlternative.java
@@ -1,0 +1,67 @@
+package org.jboss.cdi.tck.tests.alternative.selection.priority;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Produces;
+
+@ApplicationScoped
+public class NonAltBeanProducingAlternative {
+
+    @Alternative
+    @Priority(10)
+    @Produces
+    @ProducedByMethod
+    Alpha producer1() {
+        return new Alpha(ProducerExplicitPriorityTest.ALT);
+    }
+
+    @Alternative
+    @Priority(10)
+    @Produces
+    @ProducedByMethod
+    Beta producer2() {
+        return new Beta(ProducerExplicitPriorityTest.ALT);
+    }
+
+    @Alternative
+    @Priority(10)
+    @Produces
+    @ProducedByField
+    Alpha producer3 = new Alpha(ProducerExplicitPriorityTest.ALT);
+
+    @Alternative
+    @Priority(10)
+    @Produces
+    @ProducedByField
+    Beta producer4 = new Beta(ProducerExplicitPriorityTest.ALT);
+
+    @Produces
+    @ProducedByMethod
+    @Alternative
+    @Priority(10)
+    Gamma producer5() {
+        return new Gamma(ProducerExplicitPriorityTest.ALT);
+    }
+
+    @Produces
+    @ProducedByField
+    @Alternative
+    @Priority(10)
+    Gamma producer6 = new Gamma(ProducerExplicitPriorityTest.ALT);
+
+    @Produces
+    @ProducedByMethod
+    @Alternative
+    @Priority(10)
+    Delta producer7() {
+        return new Delta(ProducerExplicitPriorityTest.ALT);
+    }
+
+    @Produces
+    @ProducedByField
+    @Alternative
+    @Priority(10)
+    Delta producer8 = new Delta(ProducerExplicitPriorityTest.ALT);
+
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/NonAltBeanWithPrioProducingAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/NonAltBeanWithPrioProducingAlternative.java
@@ -1,0 +1,23 @@
+package org.jboss.cdi.tck.tests.alternative.selection.priority;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Produces;
+
+@ApplicationScoped
+@Priority(500)
+public class NonAltBeanWithPrioProducingAlternative {
+
+    @Produces
+    @ProducedByMethod
+    @Alternative
+    Gamma producer5() {
+        return new Gamma(ProducerExplicitPriorityTest.ALT2);
+    }
+
+    @Produces
+    @ProducedByField
+    @Alternative
+    Gamma producer6 = new Gamma(ProducerExplicitPriorityTest.ALT2);
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/ProducedByField.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/ProducedByField.java
@@ -1,0 +1,11 @@
+package org.jboss.cdi.tck.tests.alternative.selection.priority;
+
+import jakarta.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ProducedByField {
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/ProducedByMethod.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/ProducedByMethod.java
@@ -1,0 +1,11 @@
+package org.jboss.cdi.tck.tests.alternative.selection.priority;
+
+import jakarta.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ProducedByMethod {
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/ProducerExplicitPriorityTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/ProducerExplicitPriorityTest.java
@@ -1,0 +1,90 @@
+package org.jboss.cdi.tck.tests.alternative.selection.priority;
+
+import static org.jboss.cdi.tck.cdi.Sections.DECLARING_SELECTED_ALTERNATIVES_APPLICATION;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecAssertions;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+@SpecVersion(spec = "cdi", version = "4.1")
+public class ProducerExplicitPriorityTest extends AbstractTest {
+
+    public static final String DEFAULT = "default";
+    public static final String ALT = "alternative";
+    public static final String ALT2 = "alternative2";
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder().withTestClassPackage(ProducerExplicitPriorityTest.class).build();
+    }
+
+    @Inject
+    @ProducedByMethod
+    Alpha alphaMethodProducer;
+
+    @Inject
+    @ProducedByField
+    Alpha alphaFieldProducer;
+
+    @Inject
+    @ProducedByMethod
+    Beta betaMethodProducer;
+
+    @Inject
+    @ProducedByField
+    Beta betaFieldProducer;
+
+    @Inject
+    @ProducedByMethod
+    Gamma gammaMethodProducer;
+
+    @Inject
+    @ProducedByField
+    Gamma gammaFieldProducer;
+
+    @Inject
+    @ProducedByMethod
+    Delta deltaMethodProducer;
+
+    @Inject
+    @ProducedByField
+    Delta deltaFieldProducer;
+
+
+    @Test
+    @SpecAssertions({@SpecAssertion(section = DECLARING_SELECTED_ALTERNATIVES_APPLICATION, id = "ca"),
+            @SpecAssertion(section = DECLARING_SELECTED_ALTERNATIVES_APPLICATION, id = "cb")})
+    public void testAlternativeProducerWithPriority() {
+        assertNotNull(alphaMethodProducer);
+        assertNotNull(alphaFieldProducer);
+
+        assertEquals(alphaMethodProducer.ping(), ALT);
+        assertEquals(alphaFieldProducer.ping(), ALT);
+    }
+
+    @Test
+    @SpecAssertion(section = DECLARING_SELECTED_ALTERNATIVES_APPLICATION, id = "dd")
+    public void testPriorityOnProducerOverPriorityOnClass() {
+        assertNotNull(betaMethodProducer);
+        assertNotNull(betaFieldProducer);
+        assertNotNull(gammaFieldProducer);
+        assertNotNull(gammaMethodProducer);
+        assertNotNull(deltaFieldProducer);
+        assertNotNull(deltaMethodProducer);
+
+        assertEquals(betaMethodProducer.ping(), ALT2);
+        assertEquals(betaFieldProducer.ping(), ALT2);
+        assertEquals(gammaFieldProducer.ping(), ALT2);
+        assertEquals(gammaMethodProducer.ping(), ALT2);
+        assertEquals(deltaFieldProducer.ping(), ALT2);
+        assertEquals(deltaMethodProducer.ping(), ALT2);
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/RegularBeanProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/RegularBeanProducer.java
@@ -1,0 +1,49 @@
+package org.jboss.cdi.tck.tests.alternative.selection.priority;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+// produces standard (non-alternative) beans that should be replaced by alternatives
+@ApplicationScoped
+public class RegularBeanProducer {
+
+    @Produces
+    @ProducedByMethod
+    Alpha producer1() {
+        return new Alpha(ProducerExplicitPriorityTest.DEFAULT);
+    }
+
+    @Produces
+    @ProducedByMethod
+    Beta producer2() {
+        return new Beta(ProducerExplicitPriorityTest.DEFAULT);
+    }
+
+    @Produces
+    @ProducedByField
+    Alpha producer3 = new Alpha(ProducerExplicitPriorityTest.DEFAULT);
+
+    @Produces
+    @ProducedByField
+    Beta producer4 = new Beta(ProducerExplicitPriorityTest.DEFAULT);
+
+    @Produces
+    @ProducedByMethod
+    Gamma producer5() {
+        return new Gamma(ProducerExplicitPriorityTest.DEFAULT);
+    }
+
+    @Produces
+    @ProducedByField
+    Gamma producer6 = new Gamma(ProducerExplicitPriorityTest.DEFAULT);
+
+    @Produces
+    @ProducedByMethod
+    Delta producer7() {
+        return new Delta(ProducerExplicitPriorityTest.DEFAULT);
+    }
+
+    @Produces
+    @ProducedByField
+    Delta producer8 = new Delta(ProducerExplicitPriorityTest.DEFAULT);
+}

--- a/impl/src/main/resources/tck-audit-cdi.xml
+++ b/impl/src/main/resources/tck-audit-cdi.xml
@@ -2227,6 +2227,28 @@
             </assertion>
         </group>
 
+        <group>
+            <text>An alternative may be given a priority for the application by placing the |@Priority| annotation on the producer field, method or resource.
+            </text>
+            <assertion id="ca">
+                <text>Test |@Priority| on a producer method.</text>
+            </assertion>
+            <assertion id="cb">
+                <text>Test |@Priority| on a producer field.</text>
+            </assertion>
+            <assertion id="cc">
+                <text>Test |@Priority| on a resource.</text>
+            </assertion>
+        </group>
+
+        <group>
+            <text>For the purpose of determining the priority of any producer method or field during ambiguity resolution, the priority of the producer method or field is considered first.
+                If the producer method or field does not have a priority, the priority of the managed bean that declares the producer method or field is used.</text>
+            <assertion id="dd">
+                <text>Test |@Priority| declared directly on producer is considered first.</text>
+            </assertion>
+        </group>
+
     </section>
 
     <section id="declaring_selected_alternatives_bean_archive" title="Declaring selected alternatives for a bean archive" level="4">

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/resource/DeltaResourceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/resource/DeltaResourceProducer.java
@@ -1,0 +1,18 @@
+package org.jboss.cdi.tck.tests.alternative.selection.resource;
+
+import jakarta.annotation.Priority;
+import jakarta.annotation.Resource;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Produces;
+
+@Dependent
+public class DeltaResourceProducer {
+
+    @Produces
+    @ProductionReady
+    @Resource(name = "test1")
+    @Alternative
+    @Priority(1)
+    String test1;
+}

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/resource/ResourceAlternativeExplicitPriorityTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/resource/ResourceAlternativeExplicitPriorityTest.java
@@ -1,0 +1,56 @@
+package org.jboss.cdi.tck.tests.alternative.selection.resource;
+
+import static org.jboss.cdi.tck.TestGroups.INTEGRATION;
+import static org.jboss.cdi.tck.cdi.Sections.DECLARING_SELECTED_ALTERNATIVES_APPLICATION;
+import static org.jboss.cdi.tck.tests.alternative.selection.SelectedAlternativeTestUtil.createBuilderBase;
+
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.tests.alternative.selection.Alpha;
+import org.jboss.cdi.tck.tests.alternative.selection.Bravo;
+import org.jboss.cdi.tck.tests.alternative.selection.Charlie;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.webapp30.WebAppDescriptor;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+/**
+ * Tests that alternative resource can declare {@link jakarta.annotation.Priority} directly on the producer in order
+ * to globally enable such a bean.
+ */
+@SpecVersion(spec = "cdi", version = "4.1")
+public class ResourceAlternativeExplicitPriorityTest extends AbstractTest {
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return createBuilderBase()
+                .withTestClass(ResourceAlternativeExplicitPriorityTest.class)
+                .withLibrary(ProductionReady.class)
+                .withClasses(Alpha.class)
+                .withBeanLibrary(Bravo.class, DeltaResourceProducer.class)
+                .withBeanLibrary(Charlie.class)
+                .withWebXml(
+                        Descriptors.create(WebAppDescriptor.class).createEnvEntry().envEntryName("test1")
+                                .envEntryType("java.lang.String").envEntryValue("hello").up()).build();
+    }
+
+    @Inject
+    Alpha alpha;
+
+    @Inject
+    Bravo bravo;
+
+    @Inject
+    Charlie charlie;
+
+    @Test(groups = { INTEGRATION })
+    @SpecAssertion(section = DECLARING_SELECTED_ALTERNATIVES_APPLICATION, id = "cc")
+    public void testAlternativeResourceSelected() {
+        alpha.assertAvailable(String.class, ProductionReady.ProductionReadyLiteral.INSTANCE);
+        bravo.assertAvailable(String.class, ProductionReady.ProductionReadyLiteral.INSTANCE);
+        charlie.assertAvailable(String.class, ProductionReady.ProductionReadyLiteral.INSTANCE);
+    }
+}

--- a/web/src/main/resources/tck-audit-cdi.xml
+++ b/web/src/main/resources/tck-audit-cdi.xml
@@ -2213,6 +2213,28 @@
             </assertion>
         </group>
 
+        <group>
+            <text>An alternative may be given a priority for the application by placing the |@Priority| annotation on the producer field, method or resource.
+            </text>
+            <assertion id="ca">
+                <text>Test |@Priority| on a producer method.</text>
+            </assertion>
+            <assertion id="cb">
+                <text>Test |@Priority| on a producer field.</text>
+            </assertion>
+            <assertion id="cc">
+                <text>Test |@Priority| on a resource.</text>
+            </assertion>
+        </group>
+
+        <group>
+            <text>For the purpose of determining the priority of any producer method or field during ambiguity resolution, the priority of the producer method or field is considered first.
+                If the producer method or field does not have a priority, the priority of the managed bean that declares the producer method or field is used.</text>
+            <assertion id="dd">
+                <text>Test |@Priority| declared directly on producer is considered first.</text>
+            </assertion>
+        </group>
+
     </section>
 
     <section id="declaring_selected_alternatives_bean_archive" title="Declaring selected alternatives for a bean archive" level="4">


### PR DESCRIPTION
Fixes #498 

This is aimed to cover the addition to the spec with the assumption that basics are already covered.
More precisely, using a comment depicting this from the original issue (https://github.com/jakartaee/cdi/issues/556#issuecomment-1561343104), this PR aims to add coverage for `producer2`, `producer3`, `producer4` and `producer8`. The remaining scenarios were already possible prior to this change.

Note that the test using `@Resource` producer is in the web profile of TCK and amongst integration test group.

This is a draft ATM because the related CDI PR isn't merged yet and because it hasn't been tested with any impl so far.