### PR TITLE
Add a core test for non-alternative producers on alternative beans

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/AlternativeDeltaProducer1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/AlternativeDeltaProducer1.java
@@ -1,0 +1,17 @@
+package org.jboss.cdi.tck.tests.alternative.selection;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Produces;
+
+@ApplicationScoped
+@Alternative
+@Priority(100)
+public class AlternativeDeltaProducer1 {
+
+    @Produces
+    public Delta produce() {
+        return new Delta(SelectedAlternative03Test.ALT1);
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/AlternativeDeltaProducer2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/AlternativeDeltaProducer2.java
@@ -1,0 +1,17 @@
+package org.jboss.cdi.tck.tests.alternative.selection;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Produces;
+
+@ApplicationScoped
+@Alternative
+@Priority(200)
+public class AlternativeDeltaProducer2 {
+
+    @Produces
+    public Delta produce() {
+        return new Delta(SelectedAlternative03Test.ALT2);
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Delta.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Delta.java
@@ -1,0 +1,17 @@
+package org.jboss.cdi.tck.tests.alternative.selection;
+
+import jakarta.enterprise.inject.Vetoed;
+
+@Vetoed
+public class Delta {
+
+    String s;
+
+    public Delta(String s) {
+        this.s = s;
+    }
+
+    public String ping() {
+        return s;
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/SelectedAlternative03Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/SelectedAlternative03Test.java
@@ -1,0 +1,39 @@
+package org.jboss.cdi.tck.tests.alternative.selection;
+
+import static org.jboss.cdi.tck.cdi.Sections.UNSATISFIED_AND_AMBIG_DEPENDENCIES;
+
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+@SpecVersion(spec = "cdi", version = "4.1")
+public class SelectedAlternative03Test extends AbstractTest {
+
+    public static final String DEFAULT = "default";
+    public static final String ALT1 = "alt1";
+    public static final String ALT2 = "alt2";
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder()
+                .withTestClass(SelectedAlternative03Test.class)
+                .withClasses(Delta.class, StandardDeltaProducer.class, AlternativeDeltaProducer1.class,
+                        AlternativeDeltaProducer2.class).build();
+    }
+
+    @Inject
+    Delta delta;
+
+    @Test
+    @SpecAssertion(section = UNSATISFIED_AND_AMBIG_DEPENDENCIES, id = "cb")
+    public void testMultipleAlternativeBeansWithProducers() {
+        Assert.assertNotNull(delta);
+        Assert.assertEquals(delta.ping(), ALT2);
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/StandardDeltaProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/StandardDeltaProducer.java
@@ -1,0 +1,13 @@
+package org.jboss.cdi.tck.tests.alternative.selection;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+@ApplicationScoped
+public class StandardDeltaProducer {
+
+    @Produces
+    public Delta produce() {
+        return new Delta(SelectedAlternative03Test.DEFAULT);
+    }
+}


### PR DESCRIPTION
While working on https://github.com/jakartaee/cdi-tck/pull/499 I noticed that the scenario used in this PR is missing for Lite (for Full it is covered by `ResourceAlternative04Test`)