### PR TITLE
small improvements in Build Compatible Extensions and Language Model TCKs

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyInterceptor.java
@@ -1,0 +1,16 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.registration;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+@MyInterceptorBinding
+@Interceptor
+@Priority(1)
+public class MyInterceptor {
+    @AroundInvoke
+    public Object intercept(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyInterceptorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyInterceptorBinding.java
@@ -1,0 +1,14 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.registration;
+
+import jakarta.interceptor.InterceptorBinding;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@InterceptorBinding
+public @interface MyInterceptorBinding {
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/RegistrationExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/RegistrationExtension.java
@@ -14,6 +14,7 @@ public class RegistrationExtension implements BuildCompatibleExtension {
     private final AtomicInteger beanCounter = new AtomicInteger();
     private final AtomicInteger beanMyQualifierCounter = new AtomicInteger();
     private final AtomicInteger observerCounter = new AtomicInteger();
+    private final AtomicInteger interceptorCounter = new AtomicInteger();
 
     @Registration(types = MyService.class)
     public void beans(BeanInfo bean) {
@@ -31,6 +32,14 @@ public class RegistrationExtension implements BuildCompatibleExtension {
         }
     }
 
+    @Registration(types = MyInterceptor.class)
+    public void interceptors(BeanInfo interceptor, Messages msg) {
+        if (!interceptor.isInterceptor()) {
+            msg.error("Interceptor expected", interceptor);
+        }
+        interceptorCounter.incrementAndGet();
+    }
+
     @Validation
     public void test(Messages msg) {
         if (beanCounter.get() != 2) {
@@ -43,6 +52,10 @@ public class RegistrationExtension implements BuildCompatibleExtension {
 
         if (observerCounter.get() != 1) {
             msg.error("Should see 1 observer declared in class that implements MyService");
+        }
+
+        if (interceptorCounter.get() != 1) {
+            msg.error("Should see 1 interceptor of type MyInterceptor");
         }
     }
 }

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/JavaLangObjectMethods.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/JavaLangObjectMethods.java
@@ -1,0 +1,15 @@
+package org.jboss.cdi.lang.model.tck;
+
+import jakarta.enterprise.lang.model.declarations.ClassInfo;
+
+public class JavaLangObjectMethods /*extends Object*/ {
+    public static class Verifier {
+        public static void verify(ClassInfo clazz) {
+            assert clazz.methods().isEmpty();
+
+            ClassInfo javaLangObject = clazz.superClassDeclaration();
+            assert !javaLangObject.methods().isEmpty();
+            assert LangModelUtils.collectMethods(javaLangObject, "toString").size() == 1;
+        }
+    }
+}

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/LangModelVerifier.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/LangModelVerifier.java
@@ -46,6 +46,8 @@ public class LangModelVerifier {
     InheritedFields inheritedFields;
     InheritedAnnotations inheritedAnnotations;
 
+    JavaLangObjectMethods javaLangObjectMethods;
+
     PrimitiveTypes primitiveTypes;
     BridgeMethods bridgeMethods;
     RepeatableAnnotations repeatableAnnotations;
@@ -78,6 +80,8 @@ public class LangModelVerifier {
         InheritedMethods.Verifier.verify(LangModelUtils.classOfField(clazz, "inheritedMethods"));
         InheritedFields.Verifier.verify(LangModelUtils.classOfField(clazz, "inheritedFields"));
         InheritedAnnotations.verify(LangModelUtils.classOfField(clazz, "inheritedAnnotations"));
+
+        JavaLangObjectMethods.Verifier.verify(LangModelUtils.classOfField(clazz, "javaLangObjectMethods"));
 
         PrimitiveTypes.verify(LangModelUtils.classOfField(clazz, "primitiveTypes"));
         BridgeMethods.verify(LangModelUtils.classOfField(clazz, "bridgeMethods"));


### PR DESCRIPTION
The addition in Lang Model TCK is motivated by https://github.com/jakartaee/cdi/pull/701, the addition in `@Registration` BCE TCK is motivated by a lack of test that I recently noticed.