### PR TITLE
Exclude InvocationContextTest#testGetTargetMethod and InterceptorBindingInheritanceTest

### DIFF
--- a/impl/src/main/resources/tck-tests.xml
+++ b/impl/src/main/resources/tck-tests.xml
@@ -56,6 +56,18 @@
                     <exclude name=".*"/>
                 </methods>
             </class>
+            
+            <!-- https://github.com/jakartaee/cdi-tck/issues/468 -->
+            <class name="org.jboss.cdi.tck.interceptors.tests.contract.invocationContext.InvocationContextTest">
+                <methods>
+                    <exclude name="testGetTargetMethod"/>
+                </methods>
+            </class>
+            <class name="org.jboss.cdi.tck.tests.interceptors.definition.inheritance.InterceptorBindingInheritanceTest">
+                <methods>
+                    <exclude name=".*"/>
+                </methods>
+            </class>
         </classes>
 
     </test>


### PR DESCRIPTION
Fixes #468 

These tests are fixed for next version but for 4.0 we should just exclude them.