### PR TITLE
Address ManagedBeanTypesTest.testGenericHierarchyBeanTypes failure on Java 21 when using tck-web-suite.xml

### DIFF
--- a/web/src/main/resources/tck-tests.xml
+++ b/web/src/main/resources/tck-tests.xml
@@ -38,6 +38,12 @@
                 </methods>
             </class>
 
+            <!-- https://github.com/jakartaee/cdi-tck/issues/485 -->
+            <class name="org.jboss.cdi.tck.tests.definition.bean.types.ManagedBeanTypesTest">
+                <methods>
+                    <exclude name=".*"/>
+                </methods>
+            </class>
         </classes>
 
     </test>


### PR DESCRIPTION
Also exclude ManagedBeanTypesTest.testGenericHierarchyBeanTypes in tck-web-suite.xml for https://github.com/jakartaee/cdi-tck/issues/485

I'm not trying to use tck-web-suite.xml but seem to be doing so as I see a failure on Java 21 that might also need to be addressed elsewhere.  This change is to exclude the `ManagedBeanTypesTest.testGenericHierarchyBeanTypes` test for tck-web-suite.xml as well.  


I'm using:
> export TCK_VERSION=4.0.12
> mvn clean verify -Dincontainer -Dcdi.tck-4-0.version=${TCK_VERSION} -Dmaven.test.failure.ignore=true

With the above, I seem to using `tck-web-suite.xml` which doesn't have the same excludes as tck-core-suite.xml.

Test results are:
> [INFO] Results:
> [ERROR] Failures: 
> [ERROR]   ManagedBeanTypesTest>Arquillian.run:138->testGenericHierarchyBeanTypes:80 Set [class java.lang.Object, java.util.List<org.jboss.cdi.tck.tests.definition.bean.types.Vulture<java.lang.Integer>>, interface java.util.Collection<org.jboss.cdi.tck.tests.definition.bean.types.Vulture<java.lang.Integer>>, interface java.util.SequencedCollection<org.jboss.cdi.tck.tests.definition.bean.types.Vulture<java.lang.Integer>>, class org.jboss.cdi.tck.tests.definition.bean.types.Flock, interface java.lang.Iterable<org.jboss.cdi.tck.tests.definition.bean.types.Vulture<java.lang.Integer>>] (6) does not match array [class java.lang.Object, class org.jboss.cdi.tck.tests.definition.bean.types.Flock, java.util.List<org.jboss.cdi.tck.tests.definition.bean.types.Vulture<java.lang.Integer>>, java.util.Collection<org.jboss.cdi.tck.tests.definition.bean.types.Vulture<java.lang.Integer>>, java.lang.Iterable<org.jboss.cdi.tck.tests.definition.bean.types.Vulture<java.lang.Integer>>] (5)
> [ERROR] Tests run: 1833, Failures: 1, Errors: 0, Skipped: 0
> [INFO] 
> [ERROR] There are test failures.

I'm not really sure if this pull request should be merged versus finding out why `-Dincontainer` is using `tck-web-suite.xml` which I think would be used when passing `-Dincontainer=webprofile`.  Thoughts?