### PR TITLE
Test obtaining interceptor bindings along with interception factory

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/InterceptorBindingsWithInterceptorFactoryTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/InterceptorBindingsWithInterceptorFactoryTest.java
@@ -1,0 +1,49 @@
+package org.jboss.cdi.tck.tests.full.interceptors.contract.invocationContext;
+
+import static org.jboss.cdi.tck.TestGroups.CDI_FULL;
+import static org.jboss.cdi.tck.interceptors.InterceptorsSections.INVOCATIONCONTEXT;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+@SpecVersion(spec = "interceptors", version = "2.2")
+@Test(groups = CDI_FULL)
+public class InterceptorBindingsWithInterceptorFactoryTest extends AbstractTest {
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder().withTestClassPackage(InterceptorBindingsWithInterceptorFactoryTest.class).build();
+    }
+
+    @Test
+    @SpecAssertion(section = INVOCATIONCONTEXT, id = "n")
+    public void testInterceptorBindingsAppliedViaInterceptorFactory() {
+        Product product = getContextualReference(Product.class);
+        assertEquals(product.ping(), 42);
+        assertEquals(product.pong(), 42);
+
+        Set<Annotation> interceptor1Bindings = ProductInterceptor1.getAllBindings();
+        assertNotNull(interceptor1Bindings);
+        assertEquals(interceptor1Bindings.size(), 2);
+        assertTrue(interceptor1Bindings.contains(ProductInterceptorBinding1.Literal.INSTANCE));
+        assertTrue(interceptor1Bindings.contains(ProductInterceptorBinding2.Literal.INSTANCE));
+
+        Set<Annotation> interceptor2Bindings = ProductInterceptor2.getAllBindings();
+        assertNotNull(interceptor2Bindings);
+        assertEquals(interceptor2Bindings.size(), 2);
+        assertTrue(interceptor2Bindings.contains(ProductInterceptorBinding1.Literal.INSTANCE));
+        assertTrue(interceptor2Bindings.contains(ProductInterceptorBinding3.Literal.INSTANCE));
+
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProducerBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProducerBean.java
@@ -1,0 +1,24 @@
+package org.jboss.cdi.tck.tests.full.interceptors.contract.invocationContext;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.InterceptionFactory;
+import jakarta.enterprise.inject.spi.configurator.AnnotatedTypeConfigurator;
+
+@ApplicationScoped
+public class ProducerBean {
+
+    @Produces
+    @ApplicationScoped
+    public Product createProduct(InterceptionFactory<Product> interceptionFactory) {
+        AnnotatedTypeConfigurator<Product> configurator = interceptionFactory.configure();
+        configurator.add(ProductInterceptorBinding1.Literal.INSTANCE)
+                .filterMethods(m -> m.getJavaMember().getName().equals("ping"))
+                .findFirst().get()
+                .add(ProductInterceptorBinding2.Literal.INSTANCE);
+        configurator.filterMethods(m -> m.getJavaMember().getName().equals("pong"))
+                .findFirst().get()
+                .add(ProductInterceptorBinding3.Literal.INSTANCE);
+        return interceptionFactory.createInterceptedInstance(new Product());
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/Product.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/Product.java
@@ -1,0 +1,12 @@
+package org.jboss.cdi.tck.tests.full.interceptors.contract.invocationContext;
+
+public class Product {
+
+    public int ping() {
+        return 41;
+    }
+
+    public int pong() {
+        return 41;
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptor1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptor1.java
@@ -1,0 +1,28 @@
+package org.jboss.cdi.tck.tests.full.interceptors.contract.invocationContext;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+@Priority(Interceptor.Priority.APPLICATION + 400)
+@ProductInterceptorBinding2
+@Interceptor
+public class ProductInterceptor1 {
+
+    private static Set<Annotation> allBindings;
+
+    @AroundInvoke
+    public Object aroundInvoke(InvocationContext invocationContext) throws Exception {
+        allBindings = invocationContext.getInterceptorBindings();
+        return (1 + (Integer)invocationContext.proceed());
+    }
+
+    public static Set<Annotation> getAllBindings() {
+        return allBindings;
+    }
+
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptor2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptor2.java
@@ -1,0 +1,28 @@
+package org.jboss.cdi.tck.tests.full.interceptors.contract.invocationContext;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+@Priority(Interceptor.Priority.APPLICATION + 400)
+@ProductInterceptorBinding3
+@Interceptor
+public class ProductInterceptor2 {
+
+    private static Set<Annotation> allBindings;
+
+    @AroundInvoke
+    public Object aroundInvoke(InvocationContext invocationContext) throws Exception {
+        allBindings = invocationContext.getInterceptorBindings();
+        return (1 + (Integer)invocationContext.proceed());
+    }
+
+    public static Set<Annotation> getAllBindings() {
+        return allBindings;
+    }
+
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptorBinding1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptorBinding1.java
@@ -1,0 +1,25 @@
+package org.jboss.cdi.tck.tests.full.interceptors.contract.invocationContext;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.interceptor.InterceptorBinding;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({TYPE, METHOD})
+@Retention(RUNTIME)
+@Documented
+@InterceptorBinding
+public @interface ProductInterceptorBinding1 {
+
+    class Literal extends AnnotationLiteral<ProductInterceptorBinding1> implements ProductInterceptorBinding1 {
+
+        public static Literal INSTANCE = new Literal();
+
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptorBinding2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptorBinding2.java
@@ -1,0 +1,25 @@
+package org.jboss.cdi.tck.tests.full.interceptors.contract.invocationContext;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.interceptor.InterceptorBinding;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({ TYPE, METHOD })
+@Retention(RUNTIME)
+@Documented
+@InterceptorBinding
+public @interface ProductInterceptorBinding2 {
+
+    class Literal extends AnnotationLiteral<ProductInterceptorBinding2> implements ProductInterceptorBinding2 {
+
+        public static Literal INSTANCE = new Literal();
+
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptorBinding3.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptorBinding3.java
@@ -1,0 +1,25 @@
+package org.jboss.cdi.tck.tests.full.interceptors.contract.invocationContext;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.interceptor.InterceptorBinding;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({ TYPE, METHOD })
+@Retention(RUNTIME)
+@Documented
+@InterceptorBinding
+public @interface ProductInterceptorBinding3 {
+
+    class Literal extends AnnotationLiteral<ProductInterceptorBinding3> implements ProductInterceptorBinding3 {
+
+        public static Literal INSTANCE = new Literal();
+
+    }
+}


### PR DESCRIPTION
A follow up on https://github.com/jakartaee/cdi-tck/pull/479 which didn't have any test that would leverage interception factory as a source of bindings.