### PR TITLE
Additional tests for getting the interceptor bindings from the InvocationContext

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding15.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding15.java
@@ -1,0 +1,20 @@
+package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.interceptor.InterceptorBinding;
+
+@InterceptorBinding
+@Binding15Additional("AdditionalBinding")
+@Target({ TYPE, METHOD })
+@Retention(RUNTIME)
+public @interface Binding15 {
+
+    public class Literal extends AnnotationLiteral<Binding15> implements Binding15 {}
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding15Additional.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding15Additional.java
@@ -1,0 +1,33 @@
+package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.interceptor.InterceptorBinding;
+
+@InterceptorBinding
+@Retention(RUNTIME)
+@Target({ TYPE, METHOD })
+public @interface Binding15Additional {
+
+    String value();
+
+    public class Literal extends AnnotationLiteral<Binding15Additional> implements Binding15Additional {
+        
+        private String value;
+        
+        public Literal(String value) {
+            this.value = value;
+        }
+        
+        @Override
+        public String value() {
+            return value;
+        }
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/InvocationContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/InvocationContextTest.java
@@ -139,7 +139,8 @@ public class InvocationContextTest extends AbstractTest {
                 new PseudoBinding.Literal(), new AroundConstructBinding1.Literal()));
         assertEquals(Interceptor12.getAllBindings(), Set.of(new SimplePCBinding.Literal(), new PseudoBinding.Literal(),
                 new AroundConstructBinding1.Literal(), new Binding11.Literal(), new Binding12.Literal(),
-                new Binding13.Literal("ko"), new Binding14.Literal("foobar")));
+                new Binding13.Literal("ko"), new Binding14.Literal("foobar"),
+                new Binding15.Literal(), new Binding15Additional.Literal("AdditionalBinding")));
         assertEquals(Interceptor12.getBinding12s(), Set.of(new Binding12.Literal()));
         assertEquals(Interceptor12.getBinding12(), new Binding12.Literal());
         assertEquals(Interceptor12.getBinding5s(), Set.of());

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SimpleBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SimpleBean.java
@@ -82,6 +82,7 @@ class SimpleBean {
     @Binding12
     @Binding13("ko") // does not associate `Interceptor13` with this bean due to different annotation member
     @Binding14("foobar")
+    @Binding15 // Associates both @Binding15 and @Binding15Additional("AdditionalBinding")
     public boolean bindings() {
         return true;
     }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/ChangeInterceptorBindingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/ChangeInterceptorBindingExtension.java
@@ -1,0 +1,17 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.changeInterceptorBinding;
+
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.ClassConfig;
+import jakarta.enterprise.inject.build.compatible.spi.Enhancement;
+
+public class ChangeInterceptorBindingExtension implements BuildCompatibleExtension {
+
+    @Enhancement(types = MyService.class)
+    public void enhancement(ClassConfig config) {
+        config.methods()
+                .stream()
+                .filter(it -> "hello".equals(it.info().name()))
+                .forEach(m -> m.addAnnotation(new MyBinding.Literal("foo")));
+    }
+
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/ChangeInterceptorBindingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/ChangeInterceptorBindingTest.java
@@ -1,0 +1,36 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.changeInterceptorBinding;
+
+import static org.testng.Assert.assertEquals;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.cdi.Sections;
+import org.jboss.cdi.tck.interceptors.InterceptorsSections;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+/**
+ * Test interceptor bindings applied to methods via extension are used to bind the correct interceptor and returned from InvocationContext.getInterceptorBindings()
+ */
+@SpecVersion(spec = "cdi", version = "4.1")
+public class ChangeInterceptorBindingTest extends AbstractTest {
+    
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder()
+                .withTestClassPackage(ChangeInterceptorBindingTest.class)
+                .withBuildCompatibleExtension(ChangeInterceptorBindingExtension.class)
+                .build();
+    }
+    
+    @Test
+    @SpecAssertion(section = Sections.ENHANCEMENT_PHASE, id = "b")
+    @SpecAssertion(section = InterceptorsSections.INVOCATIONCONTEXT, id="o")
+    public void test() {
+        assertEquals(getContextualReference(MyService.class).hello(), "Intercepted(foo): Hello!");
+    }
+
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/MyBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/MyBinding.java
@@ -1,0 +1,36 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.changeInterceptorBinding;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.enterprise.util.Nonbinding;
+import jakarta.interceptor.InterceptorBinding;
+
+@InterceptorBinding
+@Inherited
+@Retention(RUNTIME)
+@Target({ TYPE, METHOD })
+public @interface MyBinding {
+
+    @Nonbinding
+    public String value();
+    
+    public class Literal extends AnnotationLiteral<MyBinding> implements MyBinding {
+        private String value;
+
+        public Literal(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String value() {
+            return value;
+        }
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/MyInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/MyInterceptor.java
@@ -1,0 +1,18 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.changeInterceptorBinding;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+@Interceptor
+@MyBinding("")
+@Priority(1000)
+public class MyInterceptor {
+
+    @AroundInvoke
+    public Object aroundInvoke(InvocationContext ctx) throws Exception {
+        MyBinding binding = ctx.getInterceptorBinding(MyBinding.class);
+        return "Intercepted(" + binding.value() + "): " + ctx.proceed();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/MyService.java
@@ -1,0 +1,11 @@
+package org.jboss.cdi.tck.tests.build.compatible.extensions.changeInterceptorBinding;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class MyService {
+
+    public String hello() {
+        return "Hello!";
+    }
+}


### PR DESCRIPTION
Follow up to #479 to add a few more tests.

1. Extend `InvocationContextTest` to include an interceptor binding annotation which is annotated with another interceptor binding.
2. Test applying an interceptor binding to a method using an extension and then retrieving the binding from the InvocationContext.