### PR TITLE
Updates for TCK 4.0.x release

### DIFF
--- a/dist-build/src/main/assembly/assembly.xml
+++ b/dist-build/src/main/assembly/assembly.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 https://maven.apache.org/xsd/assembly-2.2.0.xsd">
    <id>dist</id>
    <baseDirectory>cdi-tck-${cdi.tck.version}</baseDirectory>
    <formats>

--- a/doc/reference/pom.xml
+++ b/doc/reference/pom.xml
@@ -122,13 +122,14 @@
             </plugin>
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <phase>process-classes</phase>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <copy file="${basedir}/target/generated-docs-pdf/${pdf.name}" todir="${basedir}" />
-                            </tasks>
+                            </target>
                         </configuration>
                         <goals>
                             <goal>run</goal>

--- a/doc/reference/src/main/assembly/assembly.xml
+++ b/doc/reference/src/main/assembly/assembly.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 https://maven.apache.org/xsd/assembly-2.2.0.xsd">
+   <id>bin</id>
    <baseDirectory>cdi-tck-ref-guide</baseDirectory>
    <formats>
       <format>zip</format>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
 	<selenium.version>4.7.2</selenium.version>
         <!-- Required for distribution build, should be overriden for each build -->
         <cdi.tck.version>${project.version}</cdi.tck.version>
-        <weld.version>5.0.0.SP2</weld.version>
+        <weld.version>5.1.2.Final</weld.version>
     </properties>
 
     <!-- Dependency management -->


### PR DESCRIPTION
I've been trying to issue a release for 4.0 branch and there are build failures due to some newer maven plugin being picked up.
This PR contains part of changes that were done for the main branch via https://github.com/jakartaee/cdi-tck/pull/504