### PR TITLE
add more tests for InvocationContext.getInterceptorBindings()

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding16.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding16.java
@@ -1,0 +1,34 @@
+package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.enterprise.util.Nonbinding;
+import jakarta.interceptor.InterceptorBinding;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@InterceptorBinding
+@Inherited
+@Target({ TYPE, METHOD })
+@Retention(RUNTIME)
+public @interface Binding16 {
+    String value();
+
+    class Literal extends AnnotationLiteral<Binding16> implements Binding16 {
+        private final String value;
+
+        public Literal(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String value() {
+            return value;
+        }
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/InvocationContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/InvocationContextTest.java
@@ -133,14 +133,17 @@ public class InvocationContextTest extends AbstractTest {
         assertTrue(getContextualReference(SimpleBean.class).bindings());
         assertEquals(AroundConstructInterceptor1.getAllBindings(), Set.of(new SimplePCBinding.Literal(),
                 new PseudoBinding.Literal(), new AroundConstructBinding1.Literal(),
-                new AroundConstructBinding2.Literal()));
+                new AroundConstructBinding2.Literal(), new Binding16.Literal("class-level"),
+                new SuperBinding.Literal()));
         assertEquals(AroundConstructInterceptor1.getAllBindings(), AroundConstructInterceptor2.getAllBindings());
         assertEquals(PostConstructInterceptor.getAllBindings(), Set.of(new SimplePCBinding.Literal(),
-                new PseudoBinding.Literal(), new AroundConstructBinding1.Literal()));
+                new PseudoBinding.Literal(), new AroundConstructBinding1.Literal(),
+                new Binding16.Literal("class-level"), new SuperBinding.Literal()));
         assertEquals(Interceptor12.getAllBindings(), Set.of(new SimplePCBinding.Literal(), new PseudoBinding.Literal(),
                 new AroundConstructBinding1.Literal(), new Binding11.Literal(), new Binding12.Literal(),
                 new Binding13.Literal("ko"), new Binding14.Literal("foobar"),
-                new Binding15.Literal(), new Binding15Additional.Literal("AdditionalBinding")));
+                new Binding15.Literal(), new Binding15Additional.Literal("AdditionalBinding"),
+                new Binding16.Literal("method-level"), new SuperBinding.Literal()));
         assertEquals(Interceptor12.getBinding12s(), Set.of(new Binding12.Literal()));
         assertEquals(Interceptor12.getBinding12(), new Binding12.Literal());
         assertEquals(Interceptor12.getBinding5s(), Set.of());

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SimpleBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SimpleBean.java
@@ -21,8 +21,9 @@ import jakarta.enterprise.context.Dependent;
 @SimplePCBinding
 @PseudoBinding
 @AroundConstructBinding1
+@Binding16("class-level")
 @Dependent
-class SimpleBean {
+class SimpleBean extends SuperClass {
     private int id = 0;
     private static boolean echoCalled = false;
 
@@ -83,6 +84,7 @@ class SimpleBean {
     @Binding13("ko") // does not associate `Interceptor13` with this bean due to different annotation member
     @Binding14("foobar")
     @Binding15 // Associates both @Binding15 and @Binding15Additional("AdditionalBinding")
+    @Binding16("method-level")
     public boolean bindings() {
         return true;
     }

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SuperBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SuperBinding.java
@@ -1,0 +1,20 @@
+package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.interceptor.InterceptorBinding;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@InterceptorBinding
+@Inherited
+@Target({ TYPE, METHOD })
+@Retention(RUNTIME)
+public @interface SuperBinding {
+    class Literal extends AnnotationLiteral<SuperBinding> implements SuperBinding {}
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SuperClass.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SuperClass.java
@@ -1,0 +1,5 @@
+package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
+
+@SuperBinding
+public class SuperClass {
+}


### PR DESCRIPTION
- interceptor binding inherited from a superclass
- method-level interceptor binding "overriding" a class-level interceptor binding of the same type

Follows up on #522