### PR TITLE
Add missing copyright headers to Java source files

### DIFF
--- a/api/src/main/java/org/jboss/cdi/tck/api/InSequence.java
+++ b/api/src/main/java/org/jboss/cdi/tck/api/InSequence.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.api;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;

--- a/impl/src/main/java/org/jboss/cdi/tck/TestSystemProperty.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/TestSystemProperty.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck;
 
 /**

--- a/impl/src/main/java/org/jboss/cdi/tck/impl/testng/SingleTestClassMethodInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/impl/testng/SingleTestClassMethodInterceptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.impl.testng;
 
 import java.util.ArrayList;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/AlphaBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/AlphaBinding.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.aroundConstruct;
 
 import java.lang.annotation.Inherited;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/PackagePrivateBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/PackagePrivateBinding.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.aroundInvoke;
 
 import java.lang.annotation.Inherited;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/PrivateBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/PrivateBinding.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.aroundInvoke;
 
 import java.lang.annotation.Inherited;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ProtectedBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ProtectedBinding.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.aroundInvoke;
 
 import java.lang.annotation.Inherited;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/exceptions/aroundInvoke/ExceptionBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/exceptions/aroundInvoke/ExceptionBinding.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.exceptions.aroundInvoke;
 
 import java.lang.annotation.Inherited;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/exceptions/aroundInvoke/SimpleBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/exceptions/aroundInvoke/SimpleBinding.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.exceptions.aroundInvoke;
 
 import java.lang.annotation.Inherited;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/BazBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/BazBinding.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.interceptorLifeCycle;
 
 

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/WeaponBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/WeaponBinding.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.interceptorLifeCycle;
 
 import java.lang.annotation.Inherited;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/BazBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/BazBinding.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.interceptorLifeCycle.aroundConstruct;
 
 

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/AroundConstructBinding1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/AroundConstructBinding1.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import jakarta.enterprise.util.AnnotationLiteral;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/AroundConstructBinding2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/AroundConstructBinding2.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import jakarta.enterprise.util.AnnotationLiteral;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/AroundConstructInterceptor1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/AroundConstructInterceptor1.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/AroundConstructInterceptor2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/AroundConstructInterceptor2.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding1.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import java.lang.annotation.Inherited;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding10.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding10.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import java.lang.annotation.Inherited;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding11.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding11.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import jakarta.enterprise.util.AnnotationLiteral;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding12.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding12.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import jakarta.enterprise.util.AnnotationLiteral;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding13.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding13.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import jakarta.enterprise.util.AnnotationLiteral;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding14.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding14.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import jakarta.enterprise.util.AnnotationLiteral;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding15.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding15.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024, IBM Corp., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import static java.lang.annotation.ElementType.METHOD;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding15Additional.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding15Additional.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024, IBM Corp., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import static java.lang.annotation.ElementType.METHOD;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding16.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding16.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import jakarta.enterprise.util.AnnotationLiteral;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding2.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import java.lang.annotation.Inherited;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding3.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding3.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import java.lang.annotation.Inherited;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding4.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding4.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import java.lang.annotation.Inherited;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding5.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding5.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import java.lang.annotation.Inherited;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding6.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding6.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import java.lang.annotation.Inherited;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding7.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding7.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import java.lang.annotation.Inherited;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor11.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor11.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor12.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor12.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor13.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor13.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor14.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor14.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/PseudoBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/PseudoBinding.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import jakarta.enterprise.util.AnnotationLiteral;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SimpleBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SimpleBinding.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import java.lang.annotation.Inherited;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SimplePCBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SimplePCBinding.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import java.lang.annotation.Inherited;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SuperBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SuperBinding.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 import jakarta.enterprise.util.AnnotationLiteral;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SuperClass.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SuperClass.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.invocationContext;
 
 @SuperBinding

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/AnimalBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/AnimalBinding.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.lifecycleCallback;
 
 import java.lang.annotation.Inherited;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/ChickenBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/ChickenBinding.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.lifecycleCallback;
 
 import java.lang.annotation.Inherited;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/DogBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/DogBinding.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.lifecycleCallback;
 
 import java.lang.annotation.Inherited;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/SheepBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/SheepBinding.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.lifecycleCallback;
 
 import java.lang.annotation.Inherited;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/exceptions/CatBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/exceptions/CatBinding.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.lifecycleCallback.exceptions;
 
 import java.lang.annotation.Inherited;

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/exceptions/GoatBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/exceptions/GoatBinding.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.lifecycleCallback.exceptions;
 
 import java.lang.annotation.Inherited;

--- a/impl/src/main/java/org/jboss/cdi/tck/literals/InheritedLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/literals/InheritedLiteral.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.literals;
 
 import jakarta.enterprise.util.AnnotationLiteral;

--- a/impl/src/main/java/org/jboss/cdi/tck/literals/OverrideLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/literals/OverrideLiteral.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.literals;
 
 import jakarta.enterprise.util.AnnotationLiteral;

--- a/impl/src/main/java/org/jboss/cdi/tck/literals/StereotypeLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/literals/StereotypeLiteral.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.literals;
 
 import jakarta.enterprise.inject.Stereotype;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/AlternativeDeltaProducer1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/AlternativeDeltaProducer1.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.alternative.selection;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/AlternativeDeltaProducer2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/AlternativeDeltaProducer2.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.alternative.selection;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Delta.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Delta.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.alternative.selection;
 
 import jakarta.enterprise.inject.Vetoed;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/SelectedAlternative03Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/SelectedAlternative03Test.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.alternative.selection;
 
 import static org.jboss.cdi.tck.cdi.Sections.UNSATISFIED_AND_AMBIG_DEPENDENCIES;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/StandardDeltaProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/StandardDeltaProducer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.alternative.selection;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/Alpha.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/Alpha.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.alternative.selection.priority;
 
 public class Alpha {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/AltBeanProducingAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/AltBeanProducingAlternative.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.alternative.selection.priority;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/AltBeanProducingPrioritizedNonAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/AltBeanProducingPrioritizedNonAlternative.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.alternative.selection.priority;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/Beta.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/Beta.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.alternative.selection.priority;
 
 public class Beta {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/Delta.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/Delta.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.alternative.selection.priority;
 
 public class Delta {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/Gamma.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/Gamma.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.alternative.selection.priority;
 
 public class Gamma {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/NonAltBeanProducingAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/NonAltBeanProducingAlternative.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.alternative.selection.priority;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/NonAltBeanWithPrioProducingAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/NonAltBeanWithPrioProducingAlternative.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.alternative.selection.priority;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/ProducedByField.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/ProducedByField.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.alternative.selection.priority;
 
 import jakarta.inject.Qualifier;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/ProducedByMethod.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/ProducedByMethod.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.alternative.selection.priority;
 
 import jakarta.inject.Qualifier;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/ProducerExplicitPriorityTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/ProducerExplicitPriorityTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.alternative.selection.priority;
 
 import static org.jboss.cdi.tck.cdi.Sections.DECLARING_SELECTED_ALTERNATIVES_APPLICATION;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/RegularBeanProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/RegularBeanProducer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.alternative.selection.priority;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/ContextRegisteringExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/ContextRegisteringExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.beanContainer;
 
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/CustomContextImpl1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/CustomContextImpl1.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.beanContainer;
 
 import jakarta.enterprise.context.spi.AlterableContext;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/CustomContextImpl2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/CustomContextImpl2.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.beanContainer;
 
 import jakarta.enterprise.context.spi.AlterableContext;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/CustomScoped.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/CustomScoped.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.beanContainer;
 
 import static java.lang.annotation.ElementType.FIELD;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/NoImplScope.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/NoImplScope.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.beanContainer;
 
 import static java.lang.annotation.ElementType.FIELD;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/injection/BeanContainerInjectionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/injection/BeanContainerInjectionTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.beanContainer.injection;
 
 import static org.jboss.cdi.tck.cdi.Sections.BEANCONTAINER;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/injection/MyBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/injection/MyBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.beanContainer.injection;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/ChangeBeanQualifierExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/ChangeBeanQualifierExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.changeBeanQualifier;
 
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/ChangeBeanQualifierTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/ChangeBeanQualifierTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.changeBeanQualifier;
 
 import org.jboss.arquillian.container.test.api.Deployment;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/MyOtherService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/MyOtherService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.changeBeanQualifier;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/MyQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/MyQualifier.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.changeBeanQualifier;
 
 import jakarta.inject.Qualifier;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/MyService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.changeBeanQualifier;
 
 public interface MyService {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/MyServiceBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/MyServiceBar.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.changeBeanQualifier;
 
 public class MyServiceBar implements MyService {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/MyServiceBaz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/MyServiceBaz.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.changeBeanQualifier;
 
 public class MyServiceBaz implements MyService {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/MyServiceFoo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/MyServiceFoo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.changeBeanQualifier;
 
 @MyQualifier

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/ChangeInjectionPointExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/ChangeInjectionPointExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.changeInjectionPoint;
 
 import jakarta.enterprise.inject.build.compatible.spi.AnnotationBuilder;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/ChangeInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/ChangeInjectionPointTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.changeInjectionPoint;
 
 import org.jboss.arquillian.container.test.api.Deployment;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/MyOtherService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/MyOtherService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.changeInjectionPoint;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/MyQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/MyQualifier.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.changeInjectionPoint;
 
 import jakarta.inject.Qualifier;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/MyService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.changeInjectionPoint;
 
 public interface MyService {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/MyServiceBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/MyServiceBar.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.changeInjectionPoint;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/MyServiceFoo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/MyServiceFoo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.changeInjectionPoint;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/ChangeInterceptorBindingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/ChangeInterceptorBindingExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024, IBM Corp., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.changeInterceptorBinding;
 
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/ChangeInterceptorBindingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/ChangeInterceptorBindingTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024, IBM Corp., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.changeInterceptorBinding;
 
 import static org.testng.Assert.assertEquals;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/MyBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/MyBinding.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024, IBM Corp., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.changeInterceptorBinding;
 
 import static java.lang.annotation.ElementType.METHOD;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/MyInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/MyInterceptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024, IBM Corp., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.changeInterceptorBinding;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/MyService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024, IBM Corp., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.changeInterceptorBinding;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeObserverQualifier/ChangeObserverQualifierExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeObserverQualifier/ChangeObserverQualifierExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.changeObserverQualifier;
 
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeObserverQualifier/ChangeObserverQualifierTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeObserverQualifier/ChangeObserverQualifierTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.changeObserverQualifier;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeObserverQualifier/MyConsumer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeObserverQualifier/MyConsumer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.changeObserverQualifier;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeObserverQualifier/MyEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeObserverQualifier/MyEvent.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.changeObserverQualifier;
 
 public class MyEvent {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeObserverQualifier/MyProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeObserverQualifier/MyProducer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.changeObserverQualifier;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeObserverQualifier/MyQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeObserverQualifier/MyQualifier.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.changeObserverQualifier;
 
 import jakarta.inject.Qualifier;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customInterceptorBinding/CustomInterceptorBindingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customInterceptorBinding/CustomInterceptorBindingExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customInterceptorBinding;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customInterceptorBinding/CustomInterceptorBindingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customInterceptorBinding/CustomInterceptorBindingTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customInterceptorBinding;
 
 import org.jboss.arquillian.container.test.api.Deployment;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customInterceptorBinding/MyCustomInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customInterceptorBinding/MyCustomInterceptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customInterceptorBinding;
 
 import jakarta.interceptor.AroundInvoke;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customInterceptorBinding/MyCustomInterceptorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customInterceptorBinding/MyCustomInterceptorBinding.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customInterceptorBinding;
 
 import java.lang.annotation.Retention;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customInterceptorBinding/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customInterceptorBinding/MyService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customInterceptorBinding;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/Command.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/Command.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customNormalScope;
 
 /**

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandContext.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandContext.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customNormalScope;
 
 import jakarta.enterprise.context.ContextNotActiveException;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandContextController.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandContextController.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customNormalScope;
 
 import jakarta.enterprise.context.ContextNotActiveException;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandContextControllerCreator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandContextControllerCreator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customNormalScope;
 
 import jakarta.enterprise.inject.Instance;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandExecution.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandExecution.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customNormalScope;
 
 import java.util.Date;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandExecutionCreator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandExecutionCreator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customNormalScope;
 
 import jakarta.enterprise.inject.Instance;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandExecutor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandExecutor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customNormalScope;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandScoped.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandScoped.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customNormalScope;
 
 import jakarta.enterprise.context.NormalScope;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CustomNormalScopeExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CustomNormalScopeExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customNormalScope;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CustomNormalScopeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CustomNormalScopeTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customNormalScope;
 
 import org.jboss.arquillian.container.test.api.Deployment;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/IdService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/IdService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customNormalScope;
 
 import java.util.UUID;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/MyService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customNormalScope;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/ApplicationScopedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/ApplicationScopedBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customPseudoScope;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/CustomPseudoScopeExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/CustomPseudoScopeExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customPseudoScope;
 
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/CustomPseudoScopeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/CustomPseudoScopeTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customPseudoScope;
 
 import org.jboss.arquillian.container.test.api.Deployment;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/DependentBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/DependentBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customPseudoScope;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/Prototype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/Prototype.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customPseudoScope;
 
 import jakarta.enterprise.context.spi.Context;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/PrototypeBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/PrototypeBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customPseudoScope;
 
 import java.util.UUID;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/PrototypeContext.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/PrototypeContext.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customPseudoScope;
 
 import jakarta.enterprise.context.spi.AlterableContext;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/PrototypeScoped.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/PrototypeScoped.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customPseudoScope;
 
 import jakarta.enterprise.inject.Stereotype;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/RequestScopedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/RequestScopedBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customPseudoScope;
 
 import jakarta.enterprise.context.RequestScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customQualifier/CustomQualifierExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customQualifier/CustomQualifierExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customQualifier;
 
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customQualifier/CustomQualifierTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customQualifier/CustomQualifierTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customQualifier;
 
 import org.jboss.arquillian.container.test.api.Deployment;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customQualifier/MyCustomQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customQualifier/MyCustomQualifier.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customQualifier;
 
 import jakarta.enterprise.util.AnnotationLiteral;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customQualifier/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customQualifier/MyService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customQualifier;
 
 public interface MyService {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customQualifier/MyServiceBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customQualifier/MyServiceBar.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customQualifier;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customQualifier/MyServiceFoo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customQualifier/MyServiceFoo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customQualifier;
 
 public class MyServiceFoo implements MyService {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customStereotype/CustomStereotypeExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customStereotype/CustomStereotypeExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customStereotype;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customStereotype/CustomStereotypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customStereotype/CustomStereotypeTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customStereotype;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customStereotype/MyCustomStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customStereotype/MyCustomStereotype.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customStereotype;
 
 import java.lang.annotation.Retention;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customStereotype/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customStereotype/MyService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customStereotype;
 
 @MyCustomStereotype

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customStereotype/NotDiscoveredBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customStereotype/NotDiscoveredBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.customStereotype;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/InspectAnnotatedSubtypesExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/InspectAnnotatedSubtypesExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.inspectAnnotatedSubtypes;
 
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/InspectAnnotatedSubtypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/InspectAnnotatedSubtypesTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.inspectAnnotatedSubtypes;
 
 import org.jboss.arquillian.container.test.api.Deployment;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/MyAnnotation.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/MyAnnotation.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.inspectAnnotatedSubtypes;
 
 import java.lang.annotation.Retention;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/MyService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.inspectAnnotatedSubtypes;
 
 public interface MyService {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/MyServiceBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/MyServiceBar.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.inspectAnnotatedSubtypes;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/MyServiceBaz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/MyServiceBaz.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.inspectAnnotatedSubtypes;
 
 public class MyServiceBaz implements MyService {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/MyServiceFoo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/MyServiceFoo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.inspectAnnotatedSubtypes;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/AbstractInvalidExtensionParamTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/AbstractInvalidExtensionParamTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
 
 import org.jboss.cdi.tck.AbstractTest;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParams2Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParams2Test.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
 
 import jakarta.enterprise.inject.spi.DefinitionException;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParamsExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParamsExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
 
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParamsExtension2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParamsExtension2.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
 
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParamsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParamsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
 
 import jakarta.enterprise.inject.spi.DefinitionException;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementNoParamExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementNoParamExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
 
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementNoParamTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementNoParamTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
 
 import jakarta.enterprise.inject.spi.DefinitionException;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyMessagesExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyMessagesExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
 
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyMessagesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyMessagesTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
 
 import jakarta.enterprise.inject.spi.DefinitionException;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyTypesExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyTypesExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
 
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyTypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyTypesTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
 
 import jakarta.enterprise.inject.spi.DefinitionException;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParams2Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParams2Test.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
 
 import jakarta.enterprise.inject.spi.DefinitionException;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParamsExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParamsExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
 
 import jakarta.enterprise.inject.build.compatible.spi.BeanInfo;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParamsExtension2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParamsExtension2.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
 
 import jakarta.enterprise.inject.build.compatible.spi.BeanInfo;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParamsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParamsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
 
 import jakarta.enterprise.inject.spi.DefinitionException;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationNoParamExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationNoParamExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
 
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationNoParamTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationNoParamTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
 
 import jakarta.enterprise.inject.spi.DefinitionException;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyMessagesExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyMessagesExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
 
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyMessagesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyMessagesTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
 
 import jakarta.enterprise.inject.spi.DefinitionException;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyTypesExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyTypesExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
 
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyTypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyTypesTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
 
 import jakarta.enterprise.inject.spi.DefinitionException;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/SomeBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/SomeBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.invalid;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/priority/PriorityExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/priority/PriorityExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.priority;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/priority/PriorityTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/priority/PriorityTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.priority;
 
 import org.jboss.arquillian.container.test.api.Deployment;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyInterceptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.registration;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyInterceptorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyInterceptorBinding.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.registration;
 
 import jakarta.interceptor.InterceptorBinding;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyQualifier.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.registration;
 
 import jakarta.inject.Qualifier;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.registration;
 
 public interface MyService {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyServiceBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyServiceBar.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.registration;
 
 // intentionally not a bean, to test that producer-based bean is processed

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyServiceBarProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyServiceBarProducer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.registration;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyServiceFoo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyServiceFoo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.registration;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/RegistrationExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/RegistrationExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.registration;
 
 import jakarta.enterprise.inject.build.compatible.spi.BeanInfo;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/RegistrationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/RegistrationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.registration;
 
 import org.jboss.arquillian.container.test.api.Deployment;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyComplexValue.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyComplexValue.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBean;
 
 import java.lang.annotation.Retention;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyEnum.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyEnum.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBean;
 
 public enum MyEnum {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyPojo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyPojo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBean;
 
 public class MyPojo {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyPojoCreator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyPojoCreator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBean;
 
 import jakarta.enterprise.inject.Instance;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyPojoDisposer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyPojoDisposer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBean;
 
 import jakarta.enterprise.inject.Instance;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyQualifier.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBean;
 
 import jakarta.inject.Qualifier;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBean;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MySimpleValue.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MySimpleValue.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBean;
 
 import jakarta.enterprise.util.AnnotationLiteral;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/SyntheticBeanExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/SyntheticBeanExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBean;
 
 import jakarta.enterprise.inject.build.compatible.spi.AnnotationBuilder;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/SyntheticBeanTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/SyntheticBeanTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBean;
 
 import jakarta.enterprise.inject.Instance;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/MyApplicationScopedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/MyApplicationScopedBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionPoint;
 
 public class MyApplicationScopedBean {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/MyApplicationScopedBeanCreator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/MyApplicationScopedBeanCreator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionPoint;
 
 import jakarta.enterprise.inject.Instance;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/MyDependentBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/MyDependentBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionPoint;
 
 public class MyDependentBean {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/MyDependentBeanCreator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/MyDependentBeanCreator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionPoint;
 
 import jakarta.enterprise.inject.Instance;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/MyDependentBeanDisposer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/MyDependentBeanDisposer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionPoint;
 
 import jakarta.enterprise.inject.Instance;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/SyntheticBeanInjectionPointExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/SyntheticBeanInjectionPointExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionPoint;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/SyntheticBeanInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/SyntheticBeanInjectionPointTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanInjectionPoint;
 
 import jakarta.enterprise.inject.Instance;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanWithLookup/MyDependentBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanWithLookup/MyDependentBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanWithLookup;
 
 import jakarta.annotation.PostConstruct;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanWithLookup/MyPojo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanWithLookup/MyPojo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanWithLookup;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanWithLookup/MyPojoCreator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanWithLookup/MyPojoCreator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanWithLookup;
 
 import jakarta.enterprise.inject.Instance;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanWithLookup/MyPojoDisposer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanWithLookup/MyPojoDisposer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanWithLookup;
 
 import jakarta.enterprise.inject.Instance;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanWithLookup/SyntheticBeanWithLookupExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanWithLookup/SyntheticBeanWithLookupExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanWithLookup;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanWithLookup/SyntheticBeanWithLookupTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanWithLookup/SyntheticBeanWithLookupTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanWithLookup;
 
 import jakarta.enterprise.inject.Instance;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserver/MyEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserver/MyEvent.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticObserver;
 
 public class MyEvent {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserver/MyObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserver/MyObserver.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticObserver;
 
 import jakarta.enterprise.inject.build.compatible.spi.Parameters;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserver/MyQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserver/MyQualifier.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticObserver;
 
 import jakarta.inject.Qualifier;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserver/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserver/MyService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticObserver;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserver/SyntheticObserverExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserver/SyntheticObserverExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticObserver;
 
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserver/SyntheticObserverTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserver/SyntheticObserverTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticObserver;
 
 import org.jboss.arquillian.container.test.api.Deployment;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserverOfParameterizedType/MyData.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserverOfParameterizedType/MyData.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticObserverOfParameterizedType;
 
 public class MyData {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserverOfParameterizedType/MyObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserverOfParameterizedType/MyObserver.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticObserverOfParameterizedType;
 
 import jakarta.enterprise.inject.build.compatible.spi.Parameters;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserverOfParameterizedType/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserverOfParameterizedType/MyService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticObserverOfParameterizedType;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserverOfParameterizedType/SyntheticObserverOfParameterizedTypeExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserverOfParameterizedType/SyntheticObserverOfParameterizedTypeExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticObserverOfParameterizedType;
 
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserverOfParameterizedType/SyntheticObserverOfParameterizedTypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserverOfParameterizedType/SyntheticObserverOfParameterizedTypeTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticObserverOfParameterizedType;
 
 import org.jboss.arquillian.container.test.api.Deployment;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/validation/ValidationExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/validation/ValidationExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.validation;
 
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/validation/ValidationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/validation/ValidationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.build.compatible.extensions.validation;
 
 import jakarta.enterprise.inject.spi.DeploymentException;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/MyRequestBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/MyRequestBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.context;
 
 import jakarta.enterprise.context.RequestScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/TransactionalInterceptorDependency.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/TransactionalInterceptorDependency.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.context.dependent;
 
 import jakarta.annotation.PreDestroy;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/Gathering.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/Gathering.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.bean.types;
 
 public interface Gathering<T> extends GroupingOfCertainType<T> {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/GroupingOfCertainType.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/GroupingOfCertainType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.bean.types;
 
 public interface GroupingOfCertainType<T> {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/illegal/EagleProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/illegal/EagleProducer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.bean.types.illegal;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/DummyStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/DummyStereotype.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.scope;
 
 import static java.lang.annotation.ElementType.TYPE;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/DummyStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/DummyStereotype.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype;
 
 import static java.lang.annotation.ElementType.FIELD;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/AnotherPriorityStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/AnotherPriorityStereotype.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.broken.multiplePriorities;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/ConflictingPrioritiesFromSingleStereotypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/ConflictingPrioritiesFromSingleStereotypeTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.broken.multiplePriorities;
 
 import jakarta.enterprise.inject.spi.DefinitionException;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/ConflictingPriorityStereotypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/ConflictingPriorityStereotypesTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.broken.multiplePriorities;
 
 import jakarta.enterprise.inject.spi.DefinitionException;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/PriorityStereotype2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/PriorityStereotype2.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.broken.multiplePriorities;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/SomeBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/SomeBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.broken.multiplePriorities;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/SomeOtherBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/SomeOtherBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.broken.multiplePriorities;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/inherited/AnotherDumbStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/inherited/AnotherDumbStereotype.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.broken.multiplePriorities.inherited;
 
 import jakarta.enterprise.inject.Stereotype;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/inherited/AnotherStereotypeWithPriority.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/inherited/AnotherStereotypeWithPriority.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.broken.multiplePriorities.inherited;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/inherited/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/inherited/Foo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.broken.multiplePriorities.inherited;
 
 @AnotherDumbStereotype

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/inherited/FooAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/inherited/FooAlternative.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.broken.multiplePriorities.inherited;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/inherited/FooAncestor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/inherited/FooAncestor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.broken.multiplePriorities.inherited;
 
 import org.jboss.cdi.tck.tests.definition.stereotype.priority.inherited.DumbStereotype;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/inherited/StereotypeInheritedPriorityConflictTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/inherited/StereotypeInheritedPriorityConflictTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.broken.multiplePriorities.inherited;
 
 import jakarta.enterprise.inject.spi.DefinitionException;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/scopeConflict/transitive/AnimalStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/scopeConflict/transitive/AnimalStereotype.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.broken.scopeConflict.transitive;
 
 import jakarta.enterprise.context.RequestScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/scopeConflict/transitive/FishStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/scopeConflict/transitive/FishStereotype.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.broken.scopeConflict.transitive;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/scopeConflict/transitive/Scallop_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/scopeConflict/transitive/Scallop_Broken.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.broken.scopeConflict.transitive;
 
 /**

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/scopeConflict/transitive/TransitiveIncompatibleStereotypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/scopeConflict/transitive/TransitiveIncompatibleStereotypesTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.broken.scopeConflict.transitive;
 
 import jakarta.enterprise.inject.spi.DefinitionException;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/AlternativePriorityStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/AlternativePriorityStereotype.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.priority;
 
 import jakarta.enterprise.inject.Alternative;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/Bar.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.priority;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/BarExtended.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/BarExtended.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.priority;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/Baz.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.priority;
 
 public class Baz {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/BazAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/BazAlternative.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.priority;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/BazAlternative2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/BazAlternative2.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.priority;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/Charlie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/Charlie.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.priority;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/CharlieAltStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/CharlieAltStereotype.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.priority;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/CharlieAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/CharlieAlternative.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.priority;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/Foo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.priority;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/FooAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/FooAlternative.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.priority;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/PriorityStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/PriorityStereotype.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.priority;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/StereotypeWithPriorityTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/StereotypeWithPriorityTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.priority;
 
 import static org.testng.Assert.assertEquals;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/inherited/DumbStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/inherited/DumbStereotype.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.priority.inherited;
 
 import jakarta.enterprise.inject.Stereotype;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/inherited/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/inherited/Foo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.priority.inherited;
 
 public class Foo extends FooAncestor {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/inherited/FooAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/inherited/FooAlternative.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.priority.inherited;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/inherited/FooAncestor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/inherited/FooAncestor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.priority.inherited;
 
 @DumbStereotype

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/inherited/StereotypeInheritedPriorityTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/inherited/StereotypeInheritedPriorityTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.priority.inherited;
 
 import static org.testng.Assert.assertTrue;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/inherited/StereotypeWithPriority.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/inherited/StereotypeWithPriority.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.definition.stereotype.priority.inherited;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/EmptyBeansXmlDiscoveryTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/EmptyBeansXmlDiscoveryTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.deployment.discovery;
 
 import static org.testng.Assert.assertFalse;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/SomeAnnotatedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/SomeAnnotatedBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.deployment.discovery;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/SomeUnannotatedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/SomeUnannotatedBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.deployment.discovery;
 
 // no bean defining annotation

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/Extra.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/Extra.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.event.bindingTypes;
 
 import static java.lang.annotation.ElementType.FIELD;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/Extra.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/Extra.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.event.eventTypes;
 
 import static java.lang.annotation.ElementType.FIELD;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/lifecycle/ObservingBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/lifecycle/ObservingBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.event.lifecycle;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/lifecycle/StartupShutdownTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/lifecycle/StartupShutdownTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.event.lifecycle;
 
 import static org.jboss.cdi.tck.cdi.Sections.STARTUP_EVENT;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/Number.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/Number.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.event.observer.method;
 
 import static java.lang.annotation.ElementType.FIELD;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/DestroyForSameCreationalContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/DestroyForSameCreationalContextTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.context;
 
 import static org.jboss.cdi.tck.cdi.Sections.CONTEXT;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/DestroyedInstanceReturnedByGetTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/DestroyedInstanceReturnedByGetTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.context;
 
 import static org.jboss.cdi.tck.cdi.Sections.BEAN;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/GetFromContextualTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/GetFromContextualTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.context;
 
 import static org.jboss.cdi.tck.cdi.Sections.CONTEXT;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/GetOnInactiveContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/GetOnInactiveContextTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.context;
 
 import static org.jboss.cdi.tck.cdi.Sections.CONTEXT;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/GetWithNoCreationalContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/GetWithNoCreationalContextTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.context;
 
 import static org.jboss.cdi.tck.cdi.Sections.CONTEXT;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/dependent/DependentContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/dependent/DependentContextTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.context.dependent;
 
 import java.util.Set;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/ProducedInteger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/ProducedInteger.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.context.passivating;
 
 import static java.lang.annotation.ElementType.FIELD;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/dependent/ProducerMethodParamInjectionCorralBroken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/dependent/ProducerMethodParamInjectionCorralBroken.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.context.passivating.broken.producer.method.managed.dependent;
 
 import jakarta.enterprise.context.SessionScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/dependency/builtin/BuiltinBeanPassivationDependencyTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/dependency/builtin/BuiltinBeanPassivationDependencyTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.context.passivating.dependency.builtin;
 
 import static org.jboss.cdi.tck.TestGroups.CDI_FULL;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/producer/Universe.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/producer/Universe.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.context.passivating.producer;
 
 import java.io.Serializable;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/context/dependent/DependentContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/context/dependent/DependentContextTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.decorators.context.dependent;
 
 import jakarta.enterprise.context.spi.CreationalContext;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/lookup/clientProxy/unproxyable/decorator/DecoratoredBeanProxyTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/lookup/clientProxy/unproxyable/decorator/DecoratoredBeanProxyTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.decorators.lookup.clientProxy.unproxyable.decorator;
 
 import static org.jboss.cdi.tck.TestGroups.CDI_FULL;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/lookup/clientProxy/unproxyable/decorator/Fish.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/lookup/clientProxy/unproxyable/decorator/Fish.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.decorators.lookup.clientProxy.unproxyable.decorator;
 
 public interface Fish {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/lookup/clientProxy/unproxyable/decorator/MarineDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/lookup/clientProxy/unproxyable/decorator/MarineDecorator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.decorators.lookup.clientProxy.unproxyable.decorator;
 
 import jakarta.decorator.Decorator;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/lookup/clientProxy/unproxyable/decorator/TestBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/lookup/clientProxy/unproxyable/decorator/TestBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.decorators.lookup.clientProxy.unproxyable.decorator;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/lookup/clientProxy/unproxyable/decorator/Tuna.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/lookup/clientProxy/unproxyable/decorator/Tuna.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.decorators.lookup.clientProxy.unproxyable.decorator;
 
 public final class Tuna implements Fish {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/Bar.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.definition.bean.custom;
 
 import jakarta.inject.Inject;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Alpha2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Alpha2.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.deployment.discovery;
 
 public class Alpha2 implements Ping {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Alpha3.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Alpha3.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.deployment.discovery;
 
 public class Alpha3 implements Ping {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/trimmed/Popular.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/trimmed/Popular.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.deployment.trimmed;
 
 import java.lang.annotation.ElementType;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/EventTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/EventTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.event;
 
 import static org.jboss.cdi.tck.TestGroups.CDI_FULL;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/fires/FireEventTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/fires/FireEventTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.event.fires;
 
 import static org.jboss.cdi.tck.TestGroups.CDI_FULL;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/priority/EventObserverOrderingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/priority/EventObserverOrderingTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.event.observer.priority;
 
 import static org.jboss.cdi.tck.TestGroups.CDI_FULL;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/AplomadoFalcon.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/AplomadoFalcon.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.extensions.annotated.delivery;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/CowBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/CowBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.extensions.beanManager;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bootstrap/unavailable/methods/Transactional.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bootstrap/unavailable/methods/Transactional.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.extensions.beanManager.bootstrap.unavailable.methods;
 
 import java.lang.annotation.Documented;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/alternativePriority/AlternativePriorityExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/alternativePriority/AlternativePriorityExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.extensions.configurators.bean.alternativePriority;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/alternativePriority/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/alternativePriority/Bar.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.extensions.configurators.bean.alternativePriority;
 
 import jakarta.enterprise.inject.Vetoed;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/alternativePriority/BeanConfiguratorAlternativePriorityTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/alternativePriority/BeanConfiguratorAlternativePriorityTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.extensions.configurators.bean.alternativePriority;
 
 import jakarta.inject.Inject;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/alternativePriority/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/alternativePriority/Foo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.extensions.configurators.bean.alternativePriority;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/CarDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/CarDecorator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.extensions.configurators.injectionPoint;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lite/coexistence/BuildCompatibleExtensionSmokeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lite/coexistence/BuildCompatibleExtensionSmokeTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.extensions.lite.coexistence;
 
 import org.jboss.arquillian.container.test.api.Deployment;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lite/coexistence/DummyBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lite/coexistence/DummyBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.extensions.lite.coexistence;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lite/coexistence/OverridenBuildCompatibleExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lite/coexistence/OverridenBuildCompatibleExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.extensions.lite.coexistence;
 
 import jakarta.enterprise.inject.build.compatible.spi.BeanInfo;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lite/coexistence/OverridingPortableExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lite/coexistence/OverridingPortableExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.extensions.lite.coexistence;
 
 import jakarta.enterprise.event.Observes;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lite/coexistence/StandardBuildCompatibleExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lite/coexistence/StandardBuildCompatibleExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.extensions.lite.coexistence;
 
 import jakarta.enterprise.inject.build.compatible.spi.BeanInfo;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lite/coexistence/StandardPortableExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lite/coexistence/StandardPortableExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.extensions.lite.coexistence;
 
 import jakarta.enterprise.event.Observes;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/disposal/method/definition/broken/decorator/Number.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/disposal/method/definition/broken/decorator/Number.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.implementation.disposal.method.definition.broken.decorator;
 
 import static java.lang.annotation.ElementType.FIELD;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/definition/broken/decorator/Number.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/definition/broken/decorator/Number.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.implementation.producer.field.definition.broken.decorator;
 
 import static java.lang.annotation.ElementType.FIELD;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/ProducerFieldLifecycleTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/ProducerFieldLifecycleTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.implementation.producer.field.lifecycle;
 
 import static org.jboss.cdi.tck.TestGroups.CDI_FULL;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/broken/decorator/Number.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/broken/decorator/Number.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.implementation.producer.method.broken.decorator;
 
 import static java.lang.annotation.ElementType.FIELD;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/definition/ProducerMethodDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/definition/ProducerMethodDefinitionTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.implementation.producer.method.definition;
 
 import static org.jboss.cdi.tck.TestGroups.CDI_FULL;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/ProducerMethodLifecycleTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/ProducerMethodLifecycleTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.implementation.producer.method.lifecycle;
 
 import static org.jboss.cdi.tck.TestGroups.CDI_FULL;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/simple/lifecycle/Bream.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/simple/lifecycle/Bream.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.implementation.simple.lifecycle;
 
 import jakarta.enterprise.context.SessionScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/simple/lifecycle/Cod.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/simple/lifecycle/Cod.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.implementation.simple.lifecycle;
 
 import jakarta.annotation.PreDestroy;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/simple/lifecycle/SimpleBeanLifecycleTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/simple/lifecycle/SimpleBeanLifecycleTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.implementation.simple.lifecycle;
 
 import static org.jboss.cdi.tck.TestGroups.CDI_FULL;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/Dog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/Dog.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.interceptors.contract.invocationContext;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/DogInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/DogInterceptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.interceptors.contract.invocationContext;
 
 import jakarta.interceptor.AroundInvoke;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/Fish.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/Fish.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.interceptors.contract.invocationContext;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/FishInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/FishInterceptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.interceptors.contract.invocationContext;
 
 import jakarta.interceptor.AroundInvoke;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/InterceptorBindingsWithAtInterceptorsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/InterceptorBindingsWithAtInterceptorsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.interceptors.contract.invocationContext;
 
 import org.jboss.arquillian.container.test.api.Deployment;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/InterceptorBindingsWithInterceptorFactoryTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/InterceptorBindingsWithInterceptorFactoryTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.interceptors.contract.invocationContext;
 
 import static org.jboss.cdi.tck.TestGroups.CDI_FULL;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProducerBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProducerBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.interceptors.contract.invocationContext;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/Product.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/Product.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.interceptors.contract.invocationContext;
 
 public class Product {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptor1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptor1.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.interceptors.contract.invocationContext;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptor2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptor2.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.interceptors.contract.invocationContext;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptorBinding1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptorBinding1.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.interceptors.contract.invocationContext;
 
 import static java.lang.annotation.ElementType.METHOD;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptorBinding2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptorBinding2.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.interceptors.contract.invocationContext;
 
 import static java.lang.annotation.ElementType.METHOD;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptorBinding3.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptorBinding3.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.interceptors.contract.invocationContext;
 
 import static java.lang.annotation.ElementType.METHOD;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorCalledBeforeDecorator/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorCalledBeforeDecorator/Foo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.interceptors.definition.interceptorCalledBeforeDecorator;
 
 public interface Foo {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorOrder/AccountBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorOrder/AccountBinding.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.interceptors.definition.interceptorOrder;
 
 import java.lang.annotation.Inherited;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/broken/raw/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/broken/raw/Foo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.lookup.dynamic.broken.raw;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/InjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/InjectionPointTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.full.lookup.injectionpoint;
 
 import static org.jboss.cdi.tck.TestGroups.CDI_FULL;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/interceptor/ProducedString.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/interceptor/ProducedString.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.implementation.disposal.method.definition.broken.interceptor;
 
 import static java.lang.annotation.ElementType.FIELD;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/interceptor/Number.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/interceptor/Number.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.implementation.producer.field.definition.broken.interceptor;
 
 import static java.lang.annotation.ElementType.FIELD;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/interceptor/Number.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/interceptor/Number.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.implementation.producer.method.broken.interceptor;
 
 import static java.lang.annotation.ElementType.FIELD;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterAnnotatedObservesAsync/BrokenProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterAnnotatedObservesAsync/BrokenProducer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.implementation.producer.method.broken.parameterAnnotatedObservesAsync;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithTypeParameter/DoubleListProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithTypeParameter/DoubleListProducer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.implementation.producer.method.broken.parameterizedTypeWithTypeParameter;
 
 import java.util.ArrayList;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithTypeParameter/ParametrizedReturnTypeWithTypeVariable02Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithTypeParameter/ParametrizedReturnTypeWithTypeVariable02Test.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.implementation.producer.method.broken.parameterizedTypeWithTypeParameter;
 
 import static org.jboss.cdi.tck.cdi.Sections.PRODUCER_METHOD;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithWildcard/ParametrizedTypeWithWildcard02Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithWildcard/ParametrizedTypeWithWildcard02Test.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.implementation.producer.method.broken.parameterizedTypeWithWildcard;
 
 import static org.jboss.cdi.tck.cdi.Sections.LEGAL_BEAN_TYPES;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Number.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Number.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.implementation.producer.method.definition;
 
 import static java.lang.annotation.ElementType.FIELD;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/SnowTiger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/SnowTiger.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.implementation.simple.definition;
 
 import jakarta.inject.Singleton;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/White.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/White.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.implementation.simple.definition;
 
 import jakarta.enterprise.inject.Stereotype;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Tame.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.implementation.simple.lifecycle;
 
 import jakarta.inject.Qualifier;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/invocation/MissileObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/invocation/MissileObserver.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.interceptors.invocation;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed/Bar.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.lookup.byname.broken.injectionPointWithNamed;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed/Baz.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.lookup.byname.broken.injectionPointWithNamed;
 
 public class Baz {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed2/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed2/Bar.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.lookup.byname.broken.injectionPointWithNamed2;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed3/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed3/Bar.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.lookup.byname.broken.injectionPointWithNamed3;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/interceptor/Fish.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/interceptor/Fish.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.lookup.clientProxy.unproxyable.interceptor;
 
 import java.lang.annotation.Documented;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/interceptor/FishInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/interceptor/FishInterceptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.lookup.clientProxy.unproxyable.interceptor;
 
 import jakarta.annotation.Priority;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/interceptor/InterceptedBeanProxyTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/interceptor/InterceptedBeanProxyTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.lookup.clientProxy.unproxyable.interceptor;
 
 import static org.jboss.cdi.tck.cdi.Sections.UNPROXYABLE;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/interceptor/TestBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/interceptor/TestBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.lookup.clientProxy.unproxyable.interceptor;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/interceptor/Tuna.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/interceptor/Tuna.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.lookup.clientProxy.unproxyable.interceptor;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Alpha.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Alpha.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.lookup.dynamic.handle;
 
 import jakarta.annotation.PostConstruct;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Bravo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Bravo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.lookup.dynamic.handle;
 
 import jakarta.annotation.PostConstruct;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Client.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Client.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.lookup.dynamic.handle;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/FirstProcessor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/FirstProcessor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.lookup.dynamic.handle;
 
 import jakarta.annotation.PreDestroy;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/InstanceHandleTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/InstanceHandleTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.lookup.dynamic.handle;
 
 import static org.jboss.cdi.tck.cdi.Sections.DYNAMIC_LOOKUP;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Juicy.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Juicy.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.lookup.dynamic.handle;
 
 import static java.lang.annotation.ElementType.FIELD;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Processor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Processor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.lookup.dynamic.handle;
 
 public interface Processor {

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/SecondProcessor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/SecondProcessor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.lookup.dynamic.handle;
 
 import jakarta.annotation.PreDestroy;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/ProducedInteger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/ProducedInteger.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.lookup.injection;
 
 import static java.lang.annotation.ElementType.FIELD;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/primitive/ProducedPrimitive.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/primitive/ProducedPrimitive.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.lookup.typesafe.resolution.primitive;
 
 import static java.lang.annotation.ElementType.FIELD;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/discovery/trimmed/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/discovery/trimmed/Foo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.se.discovery.trimmed;
 
 import jakarta.enterprise.context.Dependent;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/events/lifecycle/ObservingBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/events/lifecycle/ObservingBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.se.events.lifecycle;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/events/lifecycle/StartupShutdownTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/events/lifecycle/StartupShutdownTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.se.events.lifecycle;
 
 import static org.jboss.cdi.tck.TestGroups.SE;

--- a/impl/src/main/java/org/jboss/cdi/tck/util/DependentInstance.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/DependentInstance.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.util;
 
 import java.lang.annotation.Annotation;

--- a/impl/src/main/java/org/jboss/cdi/tck/util/ForwardingInjectionPoint.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/ForwardingInjectionPoint.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.util;
 
 import java.lang.annotation.Annotation;

--- a/impl/src/main/java/org/jboss/cdi/tck/util/annotated/AnnotatedTypes.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/annotated/AnnotatedTypes.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.util.annotated;
 
 import java.lang.reflect.Constructor;

--- a/impl/src/main/java/org/jboss/shrinkwrap/api/BeanDiscoveryMode.java
+++ b/impl/src/main/java/org/jboss/shrinkwrap/api/BeanDiscoveryMode.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.shrinkwrap.api;
 
 public enum BeanDiscoveryMode {

--- a/impl/src/main/java/org/jboss/shrinkwrap/api/BeansXmlVersion.java
+++ b/impl/src/main/java/org/jboss/shrinkwrap/api/BeansXmlVersion.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.shrinkwrap.api;
 
 public enum BeansXmlVersion {

--- a/impl/src/main/java/org/jboss/shrinkwrap/impl/BeansXml.java
+++ b/impl/src/main/java/org/jboss/shrinkwrap/impl/BeansXml.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.shrinkwrap.impl;
 
 import org.jboss.shrinkwrap.api.BeanDiscoveryMode;

--- a/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/beansxml/BeansXmlTest.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/beansxml/BeansXmlTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.test.shrinkwrap.beansxml;
 
 import org.jboss.cdi.tck.shrinkwrap.AssetUtil;

--- a/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/beansxml/DummyReferenceClass.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/beansxml/DummyReferenceClass.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.test.shrinkwrap.beansxml;
 
 public class DummyReferenceClass {

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/AnnotatedReceiverTypes.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/AnnotatedReceiverTypes.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.lang.model.tck;
 
 import jakarta.enterprise.lang.model.declarations.ClassInfo;

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/AnnotatedSuperTypes.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/AnnotatedSuperTypes.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.lang.model.tck;
 
 import jakarta.enterprise.lang.model.declarations.ClassInfo;

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/AnnotatedThrowsTypes.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/AnnotatedThrowsTypes.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.lang.model.tck;
 
 import jakarta.enterprise.lang.model.declarations.ClassInfo;

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/AnnotatedTypes.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/AnnotatedTypes.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.lang.model.tck;
 
 import jakarta.enterprise.lang.model.AnnotationInfo;

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/AnnotationInstances.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/AnnotationInstances.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.lang.model.tck;
 
 import jakarta.enterprise.lang.model.AnnotationInfo;

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/AnnotationMembers.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/AnnotationMembers.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.lang.model.tck;
 
 import jakarta.enterprise.lang.model.declarations.ClassInfo;

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/BridgeMethods.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/BridgeMethods.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.lang.model.tck;
 
 import jakarta.enterprise.lang.model.declarations.ClassInfo;

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/DefaultConstructors.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/DefaultConstructors.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.lang.model.tck;
 
 import jakarta.enterprise.lang.model.declarations.ClassInfo;

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/EnumMembers.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/EnumMembers.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.lang.model.tck;
 
 import jakarta.enterprise.lang.model.declarations.ClassInfo;

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/Equality.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/Equality.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.lang.model.tck;
 
 import jakarta.enterprise.lang.model.AnnotationTarget;

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/InheritedAnnotations.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/InheritedAnnotations.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.lang.model.tck;
 
 import jakarta.enterprise.lang.model.declarations.ClassInfo;

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/InheritedFields.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/InheritedFields.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.lang.model.tck;
 
 import jakarta.enterprise.lang.model.declarations.ClassInfo;

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/InheritedMethods.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/InheritedMethods.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.lang.model.tck;
 
 import jakarta.enterprise.lang.model.declarations.ClassInfo;

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/InterfaceMembers.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/InterfaceMembers.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.lang.model.tck;
 
 import jakarta.enterprise.lang.model.declarations.ClassInfo;

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/JavaLangObjectMethods.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/JavaLangObjectMethods.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.lang.model.tck;
 
 import jakarta.enterprise.lang.model.declarations.ClassInfo;

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/LangModelUtils.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/LangModelUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.lang.model.tck;
 
 import jakarta.enterprise.lang.model.declarations.ClassInfo;

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/LangModelVerifier.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/LangModelVerifier.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.lang.model.tck;
 
 import jakarta.enterprise.lang.model.declarations.ClassInfo;

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/MissingAnnotation.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/MissingAnnotation.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.lang.model.tck;
 
 import java.lang.annotation.Retention;

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/PlainClassMembers.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/PlainClassMembers.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.lang.model.tck;
 
 import jakarta.enterprise.lang.model.declarations.ClassInfo;

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/PrimitiveTypes.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/PrimitiveTypes.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.lang.model.tck;
 
 import jakarta.enterprise.lang.model.declarations.ClassInfo;

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/RepeatableAnnotations.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/RepeatableAnnotations.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.lang.model.tck;
 
 import jakarta.enterprise.lang.model.AnnotationInfo;

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/SimpleAnnotation.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/SimpleAnnotation.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.lang.model.tck;
 
 import java.lang.annotation.Retention;

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/SimpleClass.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/SimpleClass.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.lang.model.tck;
 
 public class SimpleClass implements SimpleInterface {

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/SimpleEnum.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/SimpleEnum.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.lang.model.tck;
 
 public enum SimpleEnum {

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/SimpleInterface.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/SimpleInterface.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.lang.model.tck;
 
 public interface SimpleInterface {

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/package-info.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/package-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 @AnnPackage("lang-model-tck")
 package org.jboss.cdi.lang.model.tck;
 

--- a/pom.xml
+++ b/pom.xml
@@ -289,6 +289,27 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <version>0.16</version>
+                <configuration>
+                    <includes>
+                        <include>**/*.java</include>
+                    </includes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>rat-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <scm>

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ee/Baz.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ee/Baz.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.interceptors.tests.contract.aroundInvoke.ee;
 
 import static org.testng.Assert.assertEquals;

--- a/web/src/main/java/org/jboss/cdi/tck/shrinkwrap/ee/DummySessionBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/shrinkwrap/ee/DummySessionBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.shrinkwrap.ee;
 
 import jakarta.ejb.Stateless;

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/enterprise/SelectedAlternativeTestUtil.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/enterprise/SelectedAlternativeTestUtil.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.alternative.selection.enterprise;
 
 import org.jboss.cdi.tck.shrinkwrap.ee.WebArchiveBuilder;

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/resource/DeltaResourceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/resource/DeltaResourceProducer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.alternative.selection.resource;
 
 import jakarta.annotation.Priority;

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/resource/ResourceAlternativeExplicitPriorityTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/resource/ResourceAlternativeExplicitPriorityTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.alternative.selection.resource;
 
 import static org.jboss.cdi.tck.TestGroups.INTEGRATION;

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/jms/AbstractMessageListener.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/jms/AbstractMessageListener.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.context.jms;
 
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/method/enterprise/ProducerMethodParamInjectionCorralBroken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/method/enterprise/ProducerMethodParamInjectionCorralBroken.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.context.passivating.broken.producer.method.enterprise;
 
 import jakarta.ejb.Stateful;

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/resource/remote/ResourcePassivationDependencyTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/resource/remote/ResourcePassivationDependencyTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.context.passivating.dependency.resource.remote;
 
 import static org.jboss.cdi.tck.TestGroups.JAVAEE_FULL;

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/sessionbean/SessionBeanPassivationDependencyTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/sessionbean/SessionBeanPassivationDependencyTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.context.passivating.dependency.sessionbean;
 
 import static org.jboss.cdi.tck.TestGroups.INTEGRATION;

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/rar/TestResourceAdapter.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/rar/TestResourceAdapter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.deployment.packaging.rar;
 
 import java.util.logging.Logger;

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/async/Counter.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/async/Counter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.event.observer.context.async;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/Foo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.event.observer.context.enterprise;
 
 public class Foo {

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/session/YoghurtInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/session/YoghurtInterceptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.implementation.builtin.metadata.session;
 
 import java.io.Serializable;

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/Bar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/Bar.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.implementation.enterprise.definition.remote;
 
 public interface Bar extends SuperBar {

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/Foo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.implementation.enterprise.definition.remote;
 
 public interface Foo {

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/SuperBar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/SuperBar.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.implementation.enterprise.definition.remote;
 
 public interface SuperBar {

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/Tame.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/Tame.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.implementation.enterprise.definition.remote;
 
 import static java.lang.annotation.ElementType.FIELD;

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/enterprise/nonstatic/Number.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/enterprise/nonstatic/Number.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.implementation.producer.field.definition.broken.enterprise.nonstatic;
 
 import static java.lang.annotation.ElementType.FIELD;

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/ee/EnterpriseBeanNotDiscoveredAsManagedBeanTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/ee/EnterpriseBeanNotDiscoveredAsManagedBeanTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.implementation.simple.definition.ee;
 
 import static org.jboss.cdi.tck.TestGroups.INTEGRATION;

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/ee/EnterpriseBeanObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/ee/EnterpriseBeanObserver.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.implementation.simple.definition.ee;
 
 import jakarta.enterprise.event.Observes;

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/sessionbean/LoginAction.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/sessionbean/LoginAction.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.inheritance.specialization.enterprise.broken.extend.sessionbean;
 
 import jakarta.ejb.Local;

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/sessionbean/LoginActionBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/sessionbean/LoginActionBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.inheritance.specialization.enterprise.broken.extend.sessionbean;
 
 import jakarta.ejb.Stateless;

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/sessionbean/Mock.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/sessionbean/Mock.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.inheritance.specialization.enterprise.broken.extend.sessionbean;
 
 import static java.lang.annotation.ElementType.FIELD;

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/sessionbean/MockLoginActionBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/sessionbean/MockLoginActionBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.inheritance.specialization.enterprise.broken.extend.sessionbean;
 
 import jakarta.ejb.Stateless;

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/ee/FooBinding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/ee/FooBinding.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.interceptors.definition.broken.finalClassInterceptor.ee;
 
 import static java.lang.annotation.ElementType.METHOD;

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/ee/MissileInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/ee/MissileInterceptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.interceptors.definition.broken.finalClassInterceptor.ee;
 
 import java.io.Serializable;

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Specialization05Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Specialization05Test.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.lookup.modules.specialization.alternative;
 
 import static org.jboss.cdi.tck.TestGroups.JAVAEE_FULL;

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Specialization06Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Specialization06Test.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.tests.lookup.modules.specialization.alternative;
 
 import static org.jboss.cdi.tck.TestGroups.JAVAEE_FULL;

--- a/web/src/test/java/org/jboss/cdi/tck/test/ExclusionListsTest.java
+++ b/web/src/test/java/org/jboss/cdi/tck/test/ExclusionListsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.cdi.tck.test;
 
 import org.testng.annotations.Test;


### PR DESCRIPTION
The copyright owner and date for each header was generated by finding the original author and date from the git history.

Add the apache RAT plugin to verify that all java files have an appropriate header.

For #525 