### PR TITLE
Bring copyright headers into agreement with NOTICE

### DIFF
--- a/api/src/main/java/org/jboss/cdi/tck/api/Configuration.java
+++ b/api/src/main/java/org/jboss/cdi/tck/api/Configuration.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/jboss/cdi/tck/api/InSequence.java
+++ b/api/src/main/java/org/jboss/cdi/tck/api/InSequence.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/jboss/cdi/tck/spi/Beans.java
+++ b/api/src/main/java/org/jboss/cdi/tck/spi/Beans.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/jboss/cdi/tck/spi/Contexts.java
+++ b/api/src/main/java/org/jboss/cdi/tck/spi/Contexts.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/jboss/cdi/tck/spi/Contextuals.java
+++ b/api/src/main/java/org/jboss/cdi/tck/spi/Contextuals.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/jboss/cdi/tck/spi/CreationalContexts.java
+++ b/api/src/main/java/org/jboss/cdi/tck/spi/CreationalContexts.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/jboss/cdi/tck/spi/EL.java
+++ b/api/src/main/java/org/jboss/cdi/tck/spi/EL.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dist-build/lang-model-tck-runner/src/test/java/org/jboss/weld/lang/model/tck/LangModelExtension.java
+++ b/dist-build/lang-model-tck-runner/src/test/java/org/jboss/weld/lang/model/tck/LangModelExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dist-build/lang-model-tck-runner/src/test/java/org/jboss/weld/lang/model/tck/LangModelTckTest.java
+++ b/dist-build/lang-model-tck-runner/src/test/java/org/jboss/weld/lang/model/tck/LangModelTckTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext-lib/src/main/java/org/jboss/cdi/tck/extlib/Strict.java
+++ b/ext-lib/src/main/java/org/jboss/cdi/tck/extlib/Strict.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext-lib/src/main/java/org/jboss/cdi/tck/extlib/StrictLiteral.java
+++ b/ext-lib/src/main/java/org/jboss/cdi/tck/extlib/StrictLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext-lib/src/main/java/org/jboss/cdi/tck/extlib/Translator.java
+++ b/ext-lib/src/main/java/org/jboss/cdi/tck/extlib/Translator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/AbstractTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/AbstractTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/TestGroups.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/TestGroups.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/TestSystemProperty.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/TestSystemProperty.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/impl/ConfigurationFactory.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/impl/ConfigurationFactory.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/impl/ConfigurationImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/impl/ConfigurationImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/impl/PropertiesBasedConfigurationBuilder.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/impl/PropertiesBasedConfigurationBuilder.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/impl/testng/ConfigurationLoggingListener.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/impl/testng/ConfigurationLoggingListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/impl/testng/ProgressLoggingTestListener.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/impl/testng/ProgressLoggingTestListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/impl/testng/SingleTestClassMethodInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/impl/testng/SingleTestClassMethodInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/AbstractInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/AbstractInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/AlphaBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/AlphaBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/AlphaInterceptor1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/AlphaInterceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/AlphaInterceptor2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/AlphaInterceptor2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/BeanOverridingTypeLevelBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/BeanOverridingTypeLevelBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/BeanWithConstructorLevelAndTypeLevelBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/BeanWithConstructorLevelAndTypeLevelBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/BeanWithConstructorLevelBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/BeanWithConstructorLevelBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/BeanWithMultipleConstructorLevelBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/BeanWithMultipleConstructorLevelBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/BeanWithTypeLevelBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/BeanWithTypeLevelBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/BravoBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/BravoBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/BravoInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/BravoInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ConstructorInterceptionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ConstructorInterceptionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/BarBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/BarBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/BarInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/BarInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/BarStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/BarStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/BazBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/BazBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/FooBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/FooBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/FooInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/FooInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/FooStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/FooStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/InvalidStereotypeInterceptorBindingAnnotationsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/InvalidStereotypeInterceptorBindingAnnotationsTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/InvalidTransitiveInterceptorBindingAnnotationsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/InvalidTransitiveInterceptorBindingAnnotationsTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/NoBazInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/NoBazInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/YesBazInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/broken/YesBazInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/members/AnimalCountInterceptorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/members/AnimalCountInterceptorBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/members/DecreasingInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/members/DecreasingInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/members/Farm.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/members/Farm.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/members/IncreasingInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/members/IncreasingInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/members/InterceptorBindingTypeWithMemberTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/members/InterceptorBindingTypeWithMemberTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/members/Plant.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/members/Plant.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/members/PlantInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/members/PlantInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/members/PlantInterceptorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/members/PlantInterceptorBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/members/VehicleCountInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/members/VehicleCountInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/members/VehicleCountInterceptorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/members/VehicleCountInterceptorBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/multiple/Deadly.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/multiple/Deadly.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/multiple/Fast.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/multiple/Fast.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/multiple/FastAndDeadlyMissile.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/multiple/FastAndDeadlyMissile.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/multiple/GuidedMissile.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/multiple/GuidedMissile.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/multiple/LockInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/multiple/LockInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/multiple/Missile.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/multiple/Missile.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/multiple/MissileInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/multiple/MissileInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/multiple/MultipleInterceptorBindingsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/multiple/MultipleInterceptorBindingsTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/multiple/Slow.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/multiple/Slow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/multiple/SlowMissile.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/multiple/SlowMissile.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/overriding/Aging.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/overriding/Aging.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/overriding/FastAgingInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/overriding/FastAgingInterceptor.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/overriding/InterceptorBindingOverridingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/overriding/InterceptorBindingOverridingTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/overriding/Negating.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/overriding/Negating.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/overriding/NegatingInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/overriding/NegatingInterceptor.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/overriding/Pony.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/overriding/Pony.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/overriding/SlowAgingInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/overriding/SlowAgingInterceptor.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/BallBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/BallBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/BallBindingLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/BallBindingLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/BasketBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/BasketBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/BasketBindingLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/BasketBindingLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ComplicatedAroundConstructInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ComplicatedAroundConstructInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ComplicatedInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ComplicatedInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ComplicatedLifecycleInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ComplicatedLifecycleInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ConstructorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ConstructorBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/CreativeBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/CreativeBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/InterceptorBindingResolutionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/InterceptorBindingResolutionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/LoggedBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/LoggedBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/LoggedService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/LoggedService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/MachineBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/MachineBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/MachineService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/MachineService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/MessageBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/MessageBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/MessageService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/MessageService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/MonitorService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/MonitorService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/PingBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/PingBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/PongBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/PongBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/RemoteMessageService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/RemoteMessageService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/RemoteService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/RemoteService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/Service.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/Service.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ServiceStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ServiceStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/TransactionalBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/TransactionalBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/AbstractInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/AbstractInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/Alpha.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/Alpha.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/AlphaBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/AlphaBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/AlphaInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/AlphaInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/AroundConstructTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/AroundConstructTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/Bravo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/Bravo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/BravoBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/BravoBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/BravoInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/BravoInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/BravoParameter.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/BravoParameter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/BravoParameterProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/BravoParameterProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/Charlie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/Charlie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/CharlieBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/CharlieBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/CharlieException.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/CharlieException.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/CharlieInterceptor1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/CharlieInterceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/CharlieInterceptor2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/CharlieInterceptor2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/AbstractInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/AbstractInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/Alpha.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/Alpha.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/AlphaBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/AlphaBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/AlphaInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/AlphaInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/AroundConstructTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/AroundConstructTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/Bravo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/Bravo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/BravoBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/BravoBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/BravoInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/BravoInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/BravoParameter.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/BravoParameter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/BravoParameterProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/BravoParameterProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/Charlie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/Charlie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/CharlieBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/CharlieBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/CharlieException.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/CharlieException.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/CharlieInterceptor1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/CharlieInterceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/CharlieInterceptor2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundConstruct/bindings/CharlieInterceptor2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/AroundInvokeAccessInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/AroundInvokeAccessInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/Bean1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/Bean1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/Bean2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/Bean2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/Bean3.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/Bean3.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/PackagePrivateBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/PackagePrivateBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/PackagePrivateInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/PackagePrivateInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/PrivateBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/PrivateBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/PrivateInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/PrivateInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ProtectedBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ProtectedBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ProtectedInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ProtectedInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/SimpleBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/SimpleBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/AroundInvokeInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/AroundInvokeInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/Binding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/Binding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/Interceptor1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/Interceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/Interceptor2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/Interceptor2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/MiddleFoo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/MiddleFoo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/MiddleInterceptor1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/MiddleInterceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/SuperFoo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/SuperFoo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/SuperInterceptor1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/SuperInterceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/SuperInterceptor2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/SuperInterceptor2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/exceptions/aroundInvoke/ExceptionBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/exceptions/aroundInvoke/ExceptionBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/exceptions/aroundInvoke/ExceptionBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/exceptions/aroundInvoke/ExceptionBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/exceptions/aroundInvoke/ExceptionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/exceptions/aroundInvoke/ExceptionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/exceptions/aroundInvoke/Interceptor1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/exceptions/aroundInvoke/Interceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/exceptions/aroundInvoke/Interceptor2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/exceptions/aroundInvoke/Interceptor2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/exceptions/aroundInvoke/Interceptor3.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/exceptions/aroundInvoke/Interceptor3.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/exceptions/aroundInvoke/Interceptor4.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/exceptions/aroundInvoke/Interceptor4.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/exceptions/aroundInvoke/SimpleBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/exceptions/aroundInvoke/SimpleBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/exceptions/aroundInvoke/SimpleBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/exceptions/aroundInvoke/SimpleBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/AroundInvokeInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/AroundInvokeInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/AttackBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/AttackBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/BazBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/BazBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/InterceptorLifeCycleTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/InterceptorLifeCycleTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/MethodBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/MethodBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/MethodInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/MethodInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/PostConstructInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/PostConstructInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/PreDestroyInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/PreDestroyInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/Warrior.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/Warrior.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/WarriorAIInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/WarriorAIInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/WarriorAttackAIInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/WarriorAttackAIInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/WarriorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/WarriorBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/WarriorPCInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/WarriorPCInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/WarriorPDInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/WarriorPDInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/Weapon.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/Weapon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/WeaponAIInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/WeaponAIInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/WeaponBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/WeaponBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/AroundConstructLifeCycleTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/AroundConstructLifeCycleTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/Baz1Interceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/Baz1Interceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/Baz2Interceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/Baz2Interceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/BazBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/BazBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/FooBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/FooBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/FooCommonInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/FooCommonInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/FooInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/FooInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/FooSuperInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/FooSuperInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/returnValueIgnored/AroundConstructInterceptorReturnValueTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/returnValueIgnored/AroundConstructInterceptorReturnValueTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/returnValueIgnored/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/returnValueIgnored/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/returnValueIgnored/FooBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/returnValueIgnored/FooBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/returnValueIgnored/FooInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/returnValueIgnored/FooInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/withAroundInvoke/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/withAroundInvoke/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/withAroundInvoke/FooBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/withAroundInvoke/FooBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/withAroundInvoke/FooInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/withAroundInvoke/FooInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/withAroundInvoke/SingleInterceptorInstanceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/aroundConstruct/withAroundInvoke/SingleInterceptorInstanceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/AroundConstructBinding1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/AroundConstructBinding1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/AroundConstructBinding2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/AroundConstructBinding2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/AroundConstructInterceptor1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/AroundConstructInterceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/AroundConstructInterceptor2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/AroundConstructInterceptor2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding10.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding10.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding11.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding11.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding12.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding12.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding13.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding13.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding14.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding14.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding15.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding15.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2024, IBM Corp., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding15Additional.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding15Additional.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2024, IBM Corp., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding16.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding16.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2024, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding3.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding3.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding4.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding4.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding5.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding5.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding6.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding6.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding7.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Binding7.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor10.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor10.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor11.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor11.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor12.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor12.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor13.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor13.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor14.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor14.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor3.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor3.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor4.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor4.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor5.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor5.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor6.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor6.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor7.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor7.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor8.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor8.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor9.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/Interceptor9.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/InvocationContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/InvocationContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/PostConstructInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/PostConstructInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/PseudoBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/PseudoBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SimpleBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SimpleBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SimpleBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SimpleBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SimplePCBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SimplePCBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SuperBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SuperBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2024, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SuperClass.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/invocationContext/SuperClass.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2024, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/AlmightyLifecycleInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/AlmightyLifecycleInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/AnimalBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/AnimalBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/AnimalInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/AnimalInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/Chicken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/Chicken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/ChickenBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/ChickenBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/Cow.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/Cow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/Dog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/Dog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/DogBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/DogBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/Goat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/Goat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/Hen.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/Hen.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/LifecycleCallbackInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/LifecycleCallbackInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/PackagePrivateLifecycleInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/PackagePrivateLifecycleInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/PrivateLifecycleInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/PrivateLifecycleInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/ProtectedLifecycleInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/ProtectedLifecycleInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/PublicLifecycleInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/PublicLifecycleInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/Sheep.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/Sheep.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/SheepBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/SheepBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/SheepInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/SheepInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/Airborne.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/Airborne.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/AirborneInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/AirborneInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/DestructionInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/DestructionInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/Destructive.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/Destructive.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/LifecycleInterceptorDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/LifecycleInterceptorDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/Missile.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/Missile.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/Rocket.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/Rocket.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/SuperDestructionInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/SuperDestructionInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/Weapon.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/Weapon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/exceptions/Cat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/exceptions/Cat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/exceptions/CatBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/exceptions/CatBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/exceptions/CatInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/exceptions/CatInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/exceptions/Goat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/exceptions/Goat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/exceptions/GoatBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/exceptions/GoatBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/exceptions/GoatInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/exceptions/GoatInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/exceptions/LifecycleCallbackInterceptorExceptionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/exceptions/LifecycleCallbackInterceptorExceptionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/exceptions/Sheep.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/exceptions/Sheep.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundConstruct/AroundConstructOrderTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundConstruct/AroundConstructOrderTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundConstruct/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundConstruct/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundConstruct/FooClassBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundConstruct/FooClassBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundConstruct/FooCtorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundConstruct/FooCtorBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundConstruct/Interceptor1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundConstruct/Interceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundConstruct/Interceptor2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundConstruct/Interceptor2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundConstruct/Interceptor3.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundConstruct/Interceptor3.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundConstruct/Interceptor4.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundConstruct/Interceptor4.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundConstruct/MiddleInterceptor1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundConstruct/MiddleInterceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundConstruct/SuperInterceptor1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundConstruct/SuperInterceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundInvoke/AroundInvokeOrderTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundInvoke/AroundInvokeOrderTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundInvoke/Interceptor1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundInvoke/Interceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundInvoke/Interceptor2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundInvoke/Interceptor2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundInvoke/Interceptor3.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundInvoke/Interceptor3.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundInvoke/Interceptor4.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundInvoke/Interceptor4.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundInvoke/Interceptor5.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundInvoke/Interceptor5.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundInvoke/OverridenInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundInvoke/OverridenInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundInvoke/RailVehicle.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundInvoke/RailVehicle.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundInvoke/Tram.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundInvoke/Tram.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundInvoke/TramClassBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundInvoke/TramClassBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundInvoke/TramCtorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundInvoke/TramCtorBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundInvoke/TramMethodBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundInvoke/TramMethodBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundInvoke/Vehicle.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/aroundInvoke/Vehicle.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/lifecycleCallback/CargoShip.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/lifecycleCallback/CargoShip.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/lifecycleCallback/Interceptor1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/lifecycleCallback/Interceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/lifecycleCallback/Interceptor2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/lifecycleCallback/Interceptor2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/lifecycleCallback/Interceptor3.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/lifecycleCallback/Interceptor3.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/lifecycleCallback/Interceptor4.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/lifecycleCallback/Interceptor4.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/lifecycleCallback/LakeCargoShip.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/lifecycleCallback/LakeCargoShip.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/lifecycleCallback/LakeCargoShipClassBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/lifecycleCallback/LakeCargoShipClassBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/lifecycleCallback/PostConstructOrderTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/lifecycleCallback/PostConstructOrderTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/lifecycleCallback/Ship.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/lifecycleCallback/Ship.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/overriden/lifecycleCallback/Bird.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/overriden/lifecycleCallback/Bird.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/overriden/lifecycleCallback/Eagle.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/overriden/lifecycleCallback/Eagle.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/overriden/lifecycleCallback/Falcon.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/overriden/lifecycleCallback/Falcon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/overriden/lifecycleCallback/OverridenLifecycleCallbackInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/order/overriden/lifecycleCallback/OverridenLifecycleCallbackInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/literals/DisposesLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/literals/DisposesLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/literals/InheritedLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/literals/InheritedLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/literals/ObservesLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/literals/ObservesLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/literals/OverrideLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/literals/OverrideLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/literals/ProducesLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/literals/ProducesLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/literals/RetentionLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/literals/RetentionLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/literals/StereotypeLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/literals/StereotypeLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/literals/TargetLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/literals/TargetLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/shrinkwrap/ArchiveBuilder.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/shrinkwrap/ArchiveBuilder.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/shrinkwrap/AssetUtil.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/shrinkwrap/AssetUtil.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/shrinkwrap/URLPackageScanner.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/shrinkwrap/URLPackageScanner.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2009, Red Hat Middleware LLC, and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/shrinkwrap/WebArchiveBuilder.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/shrinkwrap/WebArchiveBuilder.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/shrinkwrap/descriptors/Activator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/shrinkwrap/descriptors/Activator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/shrinkwrap/descriptors/ClassActivator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/shrinkwrap/descriptors/ClassActivator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/shrinkwrap/descriptors/Exclude.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/shrinkwrap/descriptors/Exclude.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/shrinkwrap/descriptors/SystemPropertyActivator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/shrinkwrap/descriptors/SystemPropertyActivator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/shrinkwrap/descriptors/ejb/EjbJarDescriptorBuilder.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/shrinkwrap/descriptors/ejb/EjbJarDescriptorBuilder.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Dungeon.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Dungeon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/False.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/False.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/FalseLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/FalseLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Forest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Forest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Larch.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Larch.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Monster.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Monster.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/QualifierInheritedTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/QualifierInheritedTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/QualifierNotDeclaredTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/QualifierNotDeclaredTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/QualifierNotInheritedTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/QualifierNotInheritedTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Qux.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Qux.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Tree.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Tree.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Troll.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/Troll.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/True.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/True.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/TrueLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/resolution/qualifier/TrueLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Alpha.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Alpha.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/AlternativeDeltaProducer1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/AlternativeDeltaProducer1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/AlternativeDeltaProducer2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/AlternativeDeltaProducer2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/AssertBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/AssertBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/BarProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/BarProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Boss.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Boss.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Bravo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Bravo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Charlie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Charlie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Delta.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Delta.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/FooProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/FooProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/SelectedAlternative01Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/SelectedAlternative01Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/SelectedAlternative02Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/SelectedAlternative02Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/SelectedAlternative03Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/SelectedAlternative03Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/SelectedAlternativeTestUtil.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/SelectedAlternativeTestUtil.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/SimpleTestBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/SimpleTestBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/StandardDeltaProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/StandardDeltaProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/TestBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/TestBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Wild.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/Wild.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/Alpha.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/Alpha.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/AltBeanProducingAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/AltBeanProducingAlternative.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/AltBeanProducingPrioritizedNonAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/AltBeanProducingPrioritizedNonAlternative.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/Beta.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/Beta.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/Delta.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/Delta.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/Gamma.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/Gamma.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/NonAltBeanProducingAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/NonAltBeanProducingAlternative.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/NonAltBeanWithPrioProducingAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/NonAltBeanWithPrioProducingAlternative.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/ProducedByField.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/ProducedByField.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/ProducedByMethod.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/ProducedByMethod.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/ProducerExplicitPriorityTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/ProducerExplicitPriorityTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/RegularBeanProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/priority/RegularBeanProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/stereotype/priority/AlternativeImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/stereotype/priority/AlternativeImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/stereotype/priority/AlternativeStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/stereotype/priority/AlternativeStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/stereotype/priority/SomeInterface.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/stereotype/priority/SomeInterface.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/stereotype/priority/StandardImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/stereotype/priority/StandardImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/stereotype/priority/StereotypeWithAlternativeSelectedByPriorityTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/stereotype/priority/StereotypeWithAlternativeSelectedByPriorityTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/AnimalStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/AnimalStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/BeanContainerTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/BeanContainerTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/ContextRegisteringExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/ContextRegisteringExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/CustomContextImpl1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/CustomContextImpl1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/CustomContextImpl2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/CustomContextImpl2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/CustomScoped.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/CustomScoped.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/Dog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/Dog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/DogHouse.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/DogHouse.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/Food.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/Food.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/Meat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/Meat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/NoImplScope.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/NoImplScope.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/Soy.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/Soy.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/Terrier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/Terrier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/Transactional.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/Transactional.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/bytype/AlternativeConnector.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/bytype/AlternativeConnector.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/bytype/BeanByTypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/bytype/BeanByTypeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/bytype/Connector.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/bytype/Connector.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/bytype/DerivedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/bytype/DerivedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/bytype/NonBindingType.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/bytype/NonBindingType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/bytype/NonBindingTypeLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/bytype/NonBindingTypeLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/bytype/SimpleBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/bytype/SimpleBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/bytype/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/bytype/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/bytype/TameLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/bytype/TameLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/injection/BeanContainerInjectionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/injection/BeanContainerInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2022, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/injection/MyBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/beanContainer/injection/MyBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2022, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/ChangeBeanQualifierExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/ChangeBeanQualifierExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/ChangeBeanQualifierTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/ChangeBeanQualifierTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/MyOtherService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/MyOtherService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/MyQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/MyQualifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/MyService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/MyServiceBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/MyServiceBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/MyServiceBaz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/MyServiceBaz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/MyServiceFoo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeBeanQualifier/MyServiceFoo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/ChangeInjectionPointExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/ChangeInjectionPointExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/ChangeInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/ChangeInjectionPointTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/MyOtherService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/MyOtherService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/MyQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/MyQualifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/MyService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/MyServiceBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/MyServiceBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/MyServiceFoo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInjectionPoint/MyServiceFoo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/ChangeInterceptorBindingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/ChangeInterceptorBindingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2024, IBM Corp., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/ChangeInterceptorBindingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/ChangeInterceptorBindingTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2024, IBM Corp., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/MyBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/MyBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2024, IBM Corp., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/MyInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/MyInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2024, IBM Corp., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeInterceptorBinding/MyService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2024, IBM Corp., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeObserverQualifier/ChangeObserverQualifierExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeObserverQualifier/ChangeObserverQualifierExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeObserverQualifier/ChangeObserverQualifierTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeObserverQualifier/ChangeObserverQualifierTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeObserverQualifier/MyConsumer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeObserverQualifier/MyConsumer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeObserverQualifier/MyEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeObserverQualifier/MyEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeObserverQualifier/MyProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeObserverQualifier/MyProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeObserverQualifier/MyQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/changeObserverQualifier/MyQualifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customInterceptorBinding/CustomInterceptorBindingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customInterceptorBinding/CustomInterceptorBindingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customInterceptorBinding/CustomInterceptorBindingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customInterceptorBinding/CustomInterceptorBindingTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customInterceptorBinding/MyCustomInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customInterceptorBinding/MyCustomInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customInterceptorBinding/MyCustomInterceptorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customInterceptorBinding/MyCustomInterceptorBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customInterceptorBinding/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customInterceptorBinding/MyService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/Command.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/Command.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandContext.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandContext.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandContextController.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandContextController.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandContextControllerCreator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandContextControllerCreator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandExecution.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandExecution.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandExecutionCreator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandExecutionCreator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandExecutor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandExecutor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandScoped.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CommandScoped.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CustomNormalScopeExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CustomNormalScopeExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CustomNormalScopeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/CustomNormalScopeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/IdService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/IdService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customNormalScope/MyService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/ApplicationScopedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/ApplicationScopedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/CustomPseudoScopeExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/CustomPseudoScopeExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/CustomPseudoScopeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/CustomPseudoScopeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/DependentBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/DependentBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/Prototype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/Prototype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/PrototypeBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/PrototypeBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/PrototypeContext.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/PrototypeContext.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/PrototypeScoped.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/PrototypeScoped.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/RequestScopedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customPseudoScope/RequestScopedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customQualifier/CustomQualifierExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customQualifier/CustomQualifierExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customQualifier/CustomQualifierTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customQualifier/CustomQualifierTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customQualifier/MyCustomQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customQualifier/MyCustomQualifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customQualifier/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customQualifier/MyService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customQualifier/MyServiceBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customQualifier/MyServiceBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customQualifier/MyServiceFoo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customQualifier/MyServiceFoo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customStereotype/CustomStereotypeExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customStereotype/CustomStereotypeExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customStereotype/CustomStereotypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customStereotype/CustomStereotypeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customStereotype/MyCustomStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customStereotype/MyCustomStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customStereotype/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customStereotype/MyService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customStereotype/NotDiscoveredBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/customStereotype/NotDiscoveredBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/InspectAnnotatedSubtypesExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/InspectAnnotatedSubtypesExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/InspectAnnotatedSubtypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/InspectAnnotatedSubtypesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/MyAnnotation.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/MyAnnotation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/MyService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/MyServiceBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/MyServiceBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/MyServiceBaz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/MyServiceBaz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/MyServiceFoo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/inspectAnnotatedSubtypes/MyServiceFoo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/AbstractInvalidExtensionParamTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/AbstractInvalidExtensionParamTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParams2Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParams2Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParamsExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParamsExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParamsExtension2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParamsExtension2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParamsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementMultipleParamsTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementNoParamExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementNoParamExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementNoParamTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementNoParamTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyMessagesExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyMessagesExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyMessagesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyMessagesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyTypesExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyTypesExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyTypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/EnhancementOnlyTypesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParams2Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParams2Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParamsExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParamsExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParamsExtension2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParamsExtension2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParamsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationMultipleParamsTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationNoParamExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationNoParamExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationNoParamTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationNoParamTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyMessagesExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyMessagesExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyMessagesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyMessagesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyTypesExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyTypesExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyTypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/RegistrationOnlyTypesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/SomeBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/invalid/SomeBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/priority/PriorityExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/priority/PriorityExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/priority/PriorityTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/priority/PriorityTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyInterceptorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyInterceptorBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyQualifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyServiceBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyServiceBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyServiceBarProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyServiceBarProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyServiceFoo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/MyServiceFoo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/RegistrationExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/RegistrationExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/RegistrationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/registration/RegistrationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyComplexValue.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyComplexValue.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyEnum.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyEnum.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyPojo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyPojo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyPojoCreator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyPojoCreator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyPojoDisposer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyPojoDisposer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyQualifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MyService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MySimpleValue.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/MySimpleValue.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/SyntheticBeanExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/SyntheticBeanExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/SyntheticBeanTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBean/SyntheticBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/MyApplicationScopedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/MyApplicationScopedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/MyApplicationScopedBeanCreator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/MyApplicationScopedBeanCreator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/MyDependentBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/MyDependentBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/MyDependentBeanCreator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/MyDependentBeanCreator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/MyDependentBeanDisposer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/MyDependentBeanDisposer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/SyntheticBeanInjectionPointExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/SyntheticBeanInjectionPointExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/SyntheticBeanInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanInjectionPoint/SyntheticBeanInjectionPointTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanWithLookup/MyDependentBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanWithLookup/MyDependentBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanWithLookup/MyPojo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanWithLookup/MyPojo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanWithLookup/MyPojoCreator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanWithLookup/MyPojoCreator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanWithLookup/MyPojoDisposer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanWithLookup/MyPojoDisposer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanWithLookup/SyntheticBeanWithLookupExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanWithLookup/SyntheticBeanWithLookupExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanWithLookup/SyntheticBeanWithLookupTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanWithLookup/SyntheticBeanWithLookupTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserver/MyEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserver/MyEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserver/MyObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserver/MyObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserver/MyQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserver/MyQualifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserver/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserver/MyService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserver/SyntheticObserverExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserver/SyntheticObserverExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserver/SyntheticObserverTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserver/SyntheticObserverTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserverOfParameterizedType/MyData.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserverOfParameterizedType/MyData.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserverOfParameterizedType/MyObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserverOfParameterizedType/MyObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserverOfParameterizedType/MyService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserverOfParameterizedType/MyService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserverOfParameterizedType/SyntheticObserverOfParameterizedTypeExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserverOfParameterizedType/SyntheticObserverOfParameterizedTypeExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserverOfParameterizedType/SyntheticObserverOfParameterizedTypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticObserverOfParameterizedType/SyntheticObserverOfParameterizedTypeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/validation/ValidationExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/validation/ValidationExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/validation/ValidationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/build/compatible/extensions/validation/ValidationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/AnotherRequestBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/AnotherRequestBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/DestroyForSameCreationalContext2Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/DestroyForSameCreationalContext2Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/DestroyForSameCreationalContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/DestroyForSameCreationalContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/DestroyedInstanceReturnedByGetTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/DestroyedInstanceReturnedByGetTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/GetFromContextualTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/GetFromContextualTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/GetOnInactiveContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/GetOnInactiveContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/GetWithNoCreationalContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/GetWithNoCreationalContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/MyApplicationBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/MyApplicationBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/MyRequestBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/MyRequestBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/alterable/AbstractComponent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/alterable/AbstractComponent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/alterable/AlterableContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/alterable/AlterableContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/alterable/ApplicationScopedComponent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/alterable/ApplicationScopedComponent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/alterable/RequestScopedComponent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/alterable/RequestScopedComponent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/AccountTransaction.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/AccountTransaction.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ApplicationHorseStable.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ApplicationHorseStable.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/DeadlyAnimal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/DeadlyAnimal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/DeadlySpider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/DeadlySpider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/DependentContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/DependentContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/DomesticationKit.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/DomesticationKit.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/Farm.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/Farm.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/Fox.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/Fox.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/FoxFarm.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/FoxFarm.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/FoxHole.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/FoxHole.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/FoxProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/FoxProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/FoxRun.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/FoxRun.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/Horse.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/Horse.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/HorseInStableEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/HorseInStableEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/HorseStable.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/HorseStable.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/OtherSpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/OtherSpiderProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/Pet.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/Pet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/SensitiveFox.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/SensitiveFox.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/Spider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/Spider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/SpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/SpiderProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/Stable.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/Stable.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/Tarantula.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/Tarantula.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/Transactional.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/Transactional.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/TransactionalInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/TransactionalInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/TransactionalInterceptorDependency.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/TransactionalInterceptorDependency.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/instance/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/instance/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/instance/BuiltinInstanceDependentObjectTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/instance/BuiltinInstanceDependentObjectTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/instance/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/instance/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/instance/GoodEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/instance/GoodEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/transientreference/Chef.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/transientreference/Chef.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/transientreference/DependentTransientReferenceDestroyedTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/transientreference/DependentTransientReferenceDestroyedTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/transientreference/Kitchen.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/transientreference/Kitchen.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/transientreference/Meal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/transientreference/Meal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/transientreference/Spoon.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/transientreference/Spoon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/transientreference/Util.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/dependent/transientreference/Util.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/AbstractAntelope.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/AbstractAntelope.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/AnimalStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/AnimalStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/BeanDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/BeanDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/ComplicatedTuna.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/ComplicatedTuna.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/DeadlyAnimal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/DeadlyAnimal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/DeadlySpider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/DeadlySpider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/DependentFinalTuna.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/DependentFinalTuna.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/FishStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/FishStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/FriendlyAntelope.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/FriendlyAntelope.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/Horse.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/Horse.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/MyBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/MyBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/MyGenericBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/MyGenericBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/MyInterface.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/MyInterface.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/MyRawBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/MyRawBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/MySuperInterface.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/MySuperInterface.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/ProducedInteger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/ProducedInteger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/RedSnapper.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/RedSnapper.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/Spider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/Spider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/SpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/SpiderProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/Tarantula.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/Tarantula.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/WolfSpider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/WolfSpider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2011, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/Boulder.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/Boulder.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2011, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/BoulderFieldProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/BoulderFieldProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2011, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/BoulderMethodProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/BoulderMethodProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2011, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/RestrictedManagedBeanTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/RestrictedManagedBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2011, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/RestrictedProducerFieldTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/RestrictedProducerFieldTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2011, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/RestrictedProducerMethodTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/RestrictedProducerMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2011, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/Stone.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/Stone.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2011, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/genericbroken/FooBroken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/genericbroken/FooBroken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/genericbroken/GenericManagedBeanTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/genericbroken/GenericManagedBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/Bird.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/Bird.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/Flock.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/Flock.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/Gathering.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/Gathering.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/GriffonVulture.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/GriffonVulture.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/GroupingOfCertainType.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/GroupingOfCertainType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/Mammal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/Mammal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/ManagedBeanTypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/ManagedBeanTypesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/Tiger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/Tiger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/Vulture.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/Vulture.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/illegal/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/illegal/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/illegal/AnimalHolder.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/illegal/AnimalHolder.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/illegal/BeanTypesWithIllegalTypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/illegal/BeanTypesWithIllegalTypeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/illegal/Bird.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/illegal/Bird.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/illegal/Eagle.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/illegal/Eagle.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/illegal/EagleProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/illegal/EagleProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/illegal/ProducedWithField.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/illegal/ProducedWithField.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/illegal/ProducedWithMethod.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/illegal/ProducedWithMethod.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/$Dollar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/$Dollar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/FishStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/FishStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/Haddock.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/Haddock.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/JSFBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/JSFBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/Minnow.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/Minnow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/Moose.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/Moose.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/NameDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/NameDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/RedSnapper.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/RedSnapper.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/RiverFishStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/RiverFishStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/SeaBass.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/SeaBass.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/_Underscore.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/_Underscore.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/lowerCase.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/name/lowerCase.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Barn.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Barn.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/BorderCollie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/BorderCollie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Cat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Cat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Chunky.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Chunky.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/ChunkyQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/ChunkyQualifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/ClippedBorderCollie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/ClippedBorderCollie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Cod.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Cod.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/DeadlyAnimal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/DeadlyAnimal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/DeadlySpider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/DeadlySpider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/DefangedTarantula.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/DefangedTarantula.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/EnglishBorderCollie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/EnglishBorderCollie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Hairy.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Hairy.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/HairyQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/HairyQualifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Horse.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Horse.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/LongHairedDog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/LongHairedDog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/MiniatureShetlandPony.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/MiniatureShetlandPony.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Produced.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Produced.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/QualifierDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/QualifierDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/ScottishFish.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/ScottishFish.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/ShetlandPony.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/ShetlandPony.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Species.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Species.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Spider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Spider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/SpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/SpiderProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Synchronous.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Synchronous.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/SynchronousQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/SynchronousQualifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/TameLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/TameLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Tarantula.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Tarantula.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Tuna.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Tuna.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Whitefish.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/Whitefish.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/WhitefishQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/WhitefishQualifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/AnyBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/AnyBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/BeanProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/BeanProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/BuiltInQualifierDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/BuiltInQualifierDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/NamedAnyBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/NamedAnyBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/NamedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/NamedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/Order.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/Order.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/OrderProcessor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/OrderProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/ProducedAnyBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/ProducedAnyBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/ProducedNamedAnyBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/ProducedNamedAnyBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/ProducedNamedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/builtin/ProducedNamedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/repeatable/Bootable.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/repeatable/Bootable.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/repeatable/Process.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/repeatable/Process.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/repeatable/ProcessObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/repeatable/ProcessObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/repeatable/ProcessProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/repeatable/ProcessProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/repeatable/RepeatableQualifiersTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/repeatable/RepeatableQualifiersTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/repeatable/Start.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/repeatable/Start.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/AnimalStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/AnimalStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/AnotherScope.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/AnotherScope.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/AnotherScopeType.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/AnotherScopeType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/BorderCollie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/BorderCollie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Clydesdale.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Clydesdale.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Dog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Dog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/DummyStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/DummyStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/EnglishBorderCollie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/EnglishBorderCollie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/FishStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/FishStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/GoldenLabrador.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/GoldenLabrador.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/GoldenRetriever.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/GoldenRetriever.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Grayling.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Grayling.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Horse.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Horse.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Labrador.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Labrador.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/MiniatureClydesdale.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/MiniatureClydesdale.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Minnow.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Minnow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Mullet.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Mullet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/NotInheritedScope.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/NotInheritedScope.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Order.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Order.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Pollock.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Pollock.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/RedSnapper.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/RedSnapper.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Retriever.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/Retriever.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/RiverFishStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/RiverFishStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/ScopeDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/ScopeDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/SeaBass.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/SeaBass.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/ShetlandPony.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/ShetlandPony.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/BeanWithTooManyScopeTypes_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/BeanWithTooManyScopeTypes_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/TooManyScopesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/TooManyScopesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/producer/field/ProducerFieldTooManyScopesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/producer/field/ProducerFieldTooManyScopesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/producer/field/ProducerFieldWithTooManyScopeTypes_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/producer/field/ProducerFieldWithTooManyScopeTypes_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/producer/field/Word.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/producer/field/Word.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/producer/method/ProducerMethodTooManyScopesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/producer/method/ProducerMethodTooManyScopesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/producer/method/ProducerMethodWithTooManyScopeTypes_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/producer/method/ProducerMethodWithTooManyScopeTypes_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/producer/method/Word.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/producer/method/Word.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/inOtherBda/ScopeDefinedInOtherBDATest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/inOtherBda/ScopeDefinedInOtherBDATest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/inOtherBda/ThirdPartyScope.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/inOtherBda/ThirdPartyScope.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/inOtherBda/ThirdPartyScopeBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/scope/inOtherBda/ThirdPartyScopeBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/AnimalStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/AnimalStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/AnotherStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/AnotherStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/ApplicationScopedHornedMammalStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/ApplicationScopedHornedMammalStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/BorderCollie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/BorderCollie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Chihuahua.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Chihuahua.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Clydesdale.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Clydesdale.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/DummyStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/DummyStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/EnglishBorderCollie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/EnglishBorderCollie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Goat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Goat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Goldfish.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Goldfish.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/HighlandCow.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/HighlandCow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/HornedMammalStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/HornedMammalStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Horse.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Horse.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/LongHairedDog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/LongHairedDog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/MexicanChihuahua.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/MexicanChihuahua.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/MiniatureClydesdale.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/MiniatureClydesdale.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Moose.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Moose.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/NonStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/NonStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Reindeer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Reindeer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/ShetlandPony.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/ShetlandPony.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/ShortHairedDog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/ShortHairedDog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Springbok.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Springbok.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/StereotypeDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/StereotypeDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/AnotherPriorityStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/AnotherPriorityStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/ConflictingPrioritiesFromSingleStereotypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/ConflictingPrioritiesFromSingleStereotypeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/ConflictingPriorityStereotypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/ConflictingPriorityStereotypesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/PriorityStereotype2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/PriorityStereotype2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/SomeBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/SomeBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/SomeOtherBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/SomeOtherBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/inherited/AnotherDumbStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/inherited/AnotherDumbStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/inherited/AnotherStereotypeWithPriority.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/inherited/AnotherStereotypeWithPriority.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/inherited/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/inherited/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/inherited/FooAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/inherited/FooAlternative.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/inherited/FooAncestor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/inherited/FooAncestor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/inherited/StereotypeInheritedPriorityConflictTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/multiplePriorities/inherited/StereotypeInheritedPriorityConflictTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/nonEmptyNamed/FallowDeer_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/nonEmptyNamed/FallowDeer_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/nonEmptyNamed/NonEmptyNamedTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/nonEmptyNamed/NonEmptyNamedTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/nonEmptyNamed/StereotypeWithNonEmptyNamed_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/nonEmptyNamed/StereotypeWithNonEmptyNamed_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/scopeConflict/AnimalStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/scopeConflict/AnimalStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/scopeConflict/FishStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/scopeConflict/FishStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/scopeConflict/IncompatibleStereotypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/scopeConflict/IncompatibleStereotypesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/scopeConflict/Scallop_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/scopeConflict/Scallop_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/scopeConflict/transitive/AnimalStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/scopeConflict/transitive/AnimalStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/scopeConflict/transitive/FishStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/scopeConflict/transitive/FishStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/scopeConflict/transitive/Scallop_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/scopeConflict/transitive/Scallop_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/scopeConflict/transitive/TransitiveIncompatibleStereotypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/scopeConflict/transitive/TransitiveIncompatibleStereotypesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/tooManyScopes/Elk_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/tooManyScopes/Elk_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/tooManyScopes/StereotypeWithTooManyScopeTypes_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/tooManyScopes/StereotypeWithTooManyScopeTypes_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/tooManyScopes/TooManyScopeTypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/tooManyScopes/TooManyScopeTypesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/withBindingType/Asynchronous.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/withBindingType/Asynchronous.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/withBindingType/RoeDeer_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/withBindingType/RoeDeer_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/withBindingType/StereoTypeWithBindingTypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/withBindingType/StereoTypeWithBindingTypesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/withBindingType/StereotypeWithBindingTypes_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/broken/withBindingType/StereotypeWithBindingTypes_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/inheritance/Horse.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/inheritance/Horse.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/inheritance/NamedRequestPolicyStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/inheritance/NamedRequestPolicyStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/inheritance/NamedRequestStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/inheritance/NamedRequestStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/inheritance/NamedStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/inheritance/NamedStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/inheritance/StereotypeInheritenceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/inheritance/StereotypeInheritenceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/Alpha.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/Alpha.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/AlphaInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/AlphaInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/AlphaOmegaStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/AlphaOmegaStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/Omega.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/Omega.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/OmegaInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/OmegaInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/StereotypeWithMultipleInterceptorBindingsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/StereotypeWithMultipleInterceptorBindingsTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/named/DefaultNamedTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/named/DefaultNamedTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/named/FallowDeer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/named/FallowDeer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/named/RoeDeer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/named/RoeDeer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/named/StereotypeWithEmptyNamed.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/named/StereotypeWithEmptyNamed.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/AlternativePriorityStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/AlternativePriorityStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/BarExtended.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/BarExtended.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/BazAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/BazAlternative.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/BazAlternative2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/BazAlternative2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/Charlie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/Charlie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/CharlieAltStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/CharlieAltStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/CharlieAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/CharlieAlternative.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/FooAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/FooAlternative.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/PriorityStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/PriorityStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/StereotypeWithPriorityTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/StereotypeWithPriorityTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/inherited/DumbStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/inherited/DumbStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/inherited/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/inherited/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/inherited/FooAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/inherited/FooAlternative.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/inherited/FooAncestor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/inherited/FooAncestor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/inherited/StereotypeInheritedPriorityTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/inherited/StereotypeInheritedPriorityTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/inherited/StereotypeWithPriority.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/priority/inherited/StereotypeWithPriority.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/EmptyBeansXmlDiscoveryTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/EmptyBeansXmlDiscoveryTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/SomeAnnotatedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/SomeAnnotatedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/SomeUnannotatedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/SomeUnannotatedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/BullTerrier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/BullTerrier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/Delivery.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/Delivery.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/Egg.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/Egg.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/EventPayload.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/EventPayload.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/EventTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/EventTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/Farmer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/Farmer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/IndirectStockWatcher.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/IndirectStockWatcher.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/IntermediateStockWatcher.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/IntermediateStockWatcher.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/LazyFarmer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/LazyFarmer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/MultiBindingEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/MultiBindingEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/OrangeCheekedWaxbill.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/OrangeCheekedWaxbill.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/PrivateObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/PrivateObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/Role.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/Role.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/RoleLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/RoleLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/StaticObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/StaticObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/StockPrice.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/StockPrice.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/StockWatcher.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/StockWatcher.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/TameAnnotationLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/TameAnnotationLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/TerrierObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/TerrierObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/Volume.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/Volume.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/AnimalAssessment.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/AnimalAssessment.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/DiscerningObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/DiscerningObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/EventBindingTypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/EventBindingTypesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/EventEmitter.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/EventEmitter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/Extra.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/Extra.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/NonBindingType.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/NonBindingType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/NonRuntimeBindingType.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/NonRuntimeBindingType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/TameAnnotationLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/TameAnnotationLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/Wild.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/Wild.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/WildAnnotationLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/bindingTypes/WildAnnotationLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/beanNotManaged/AbstractBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/beanNotManaged/AbstractBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/beanNotManaged/ConcreteBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/beanNotManaged/ConcreteBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/beanNotManaged/NonManagedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/beanNotManaged/NonManagedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/beanNotManaged/ObserverMethodOnIncorrectBeanTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/beanNotManaged/ObserverMethodOnIncorrectBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/bothObservesAnnotations/BrokenObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/bothObservesAnnotations/BrokenObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/bothObservesAnnotations/ObserverMethodParameterAnnotatedAsSyncAndAsyncTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/bothObservesAnnotations/ObserverMethodParameterAnnotatedAsSyncAndAsyncTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/dependentIsConditionalObserver/AlarmSystem.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/dependentIsConditionalObserver/AlarmSystem.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/dependentIsConditionalObserver/BreakIn.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/dependentIsConditionalObserver/BreakIn.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/dependentIsConditionalObserver/DependentIsConditionalObserverTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/dependentIsConditionalObserver/DependentIsConditionalObserverTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/inject/DeploymentFailureTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/inject/DeploymentFailureTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/inject/InitializerBean_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/inject/InitializerBean_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/isDisposer/FoxTerrier_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/isDisposer/FoxTerrier_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/isDisposer/ObserverMethodAnnotatedDisposesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/isDisposer/ObserverMethodAnnotatedDisposesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/isProducer/BorderTerrier_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/isProducer/BorderTerrier_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/isProducer/ObserverMethodAnnotatedProducesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/isProducer/ObserverMethodAnnotatedProducesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/tooManyParameters/Boxer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/tooManyParameters/Boxer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/tooManyParameters/ObserverMethodWithObservesAndObservesAsyncParametersTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/tooManyParameters/ObserverMethodWithObservesAndObservesAsyncParametersTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/tooManyParameters/ObserverMethodWithTwoEventParametersTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/tooManyParameters/ObserverMethodWithTwoEventParametersTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/tooManyParameters/Poodle_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/tooManyParameters/Poodle_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/tooManyParameters/YorkshireTerrier_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/tooManyParameters/YorkshireTerrier_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/raw/ConstructorInjectionBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/raw/ConstructorInjectionBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/raw/DisposerMethodInjectionBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/raw/DisposerMethodInjectionBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/raw/FieldInjectionBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/raw/FieldInjectionBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/raw/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/raw/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/raw/InitMethodInjectionBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/raw/InitMethodInjectionBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/raw/ObserverInjectionBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/raw/ObserverInjectionBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/raw/ProducerMethodInjectionBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/raw/ProducerMethodInjectionBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/raw/RawEventConstructorInjectionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/raw/RawEventConstructorInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/raw/RawEventDisposerInjectionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/raw/RawEventDisposerInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/raw/RawEventFieldInjectionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/raw/RawEventFieldInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/raw/RawEventInitMethodInjectionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/raw/RawEventInitMethodInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/raw/RawEventObserverInjectionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/raw/RawEventObserverInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/raw/RawEventProducerMethodInjectionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/broken/raw/RawEventProducerMethodInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/AbstractEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/AbstractEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/Artist.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/Artist.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/Broadcast.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/Broadcast.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/ComplexEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/ComplexEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/EventTypeFamilyObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/EventTypeFamilyObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/EventTypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/EventTypesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/Extra.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/Extra.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/GeneralEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/GeneralEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/Listener.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/Listener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/Solo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/Solo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/Song.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/Song.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/TuneSelect.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/eventTypes/TuneSelect.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/Billing.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/Billing.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/DogWhisperer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/DogWhisperer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/DoggiePoints.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/DoggiePoints.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/FireEventTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/FireEventTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/Housekeeping.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/Housekeeping.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/Item.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/Item.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/Item_Illegal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/Item_Illegal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/Lifted.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/Lifted.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/MiniBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/MiniBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/Praise.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/Praise.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/Restored.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/Restored.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/Role.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/Role.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/TamingCommand.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/TamingCommand.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/nonbinding/AnimalStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/nonbinding/AnimalStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/nonbinding/AnimalStereotypeAnnotationLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/nonbinding/AnimalStereotypeAnnotationLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/nonbinding/NonBindingTypePassedToFireTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/nonbinding/NonBindingTypePassedToFireTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/nonbinding/OwlFinch_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/nonbinding/OwlFinch_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/sync/FireSyncEventTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/sync/FireSyncEventTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/sync/Helper.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/sync/Helper.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/sync/Letter.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/sync/Letter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/sync/ParisPostOffice.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/sync/ParisPostOffice.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/sync/PraguePostOffice.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/fires/sync/PraguePostOffice.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/implicit/AwardEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/implicit/AwardEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/implicit/Awards.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/implicit/Awards.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/implicit/Course.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/implicit/Course.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/implicit/CourseFullEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/implicit/CourseFullEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/implicit/Honors.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/implicit/Honors.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/implicit/HonorsLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/implicit/HonorsLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/implicit/ImplicitEventTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/implicit/ImplicitEventTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/implicit/Registration.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/implicit/Registration.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/implicit/Student.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/implicit/Student.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/implicit/StudentDirectory.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/implicit/StudentDirectory.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/implicit/StudentRegisteredEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/implicit/StudentRegisteredEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/lifecycle/ObservingBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/lifecycle/ObservingBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2022, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/lifecycle/StartupShutdownTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/lifecycle/StartupShutdownTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2022, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/Alpha.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/Alpha.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/Bravo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/Bravo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/Duck.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/Duck.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/DuckNotifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/DuckNotifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/DuckObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/DuckObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/EventMetadataTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/EventMetadataTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/SimpleEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/SimpleEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/SimpleEventNotifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/SimpleEventNotifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/SimpleEventObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/SimpleEventObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/broken/initializer/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/broken/initializer/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/broken/initializer/InvalidEventMetadataInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/broken/initializer/InvalidEventMetadataInjectionPointTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/injectionpoint/EventMetadataInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/injectionpoint/EventMetadataInjectionPointTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/injectionpoint/Info.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/injectionpoint/Info.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/injectionpoint/InfoObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/injectionpoint/InfoObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/injectionpoint/Nice.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/injectionpoint/Nice.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/injectionpoint/Notifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/metadata/injectionpoint/Notifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/AnEventType.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/AnEventType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/AnObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/AnObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/AnotherEventType.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/AnotherEventType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/AnotherObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/AnotherObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/DisabledObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/DisabledObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/EventPayload.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/EventPayload.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/LastObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/LastObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/ObserverNotificationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/ObserverNotificationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/Role.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/Role.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/RoleLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/RoleLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/abortProcessing/ObserverExceptionAbortsProcessingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/abortProcessing/ObserverExceptionAbortsProcessingTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/abortProcessing/orderedObservers/ExceptionInOrderedObserversAbortsProcessingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/abortProcessing/orderedObservers/ExceptionInOrderedObserversAbortsProcessingTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/abortProcessing/orderedObservers/Invitation.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/abortProcessing/orderedObservers/Invitation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/abortProcessing/orderedObservers/OrderedObservers.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/abortProcessing/orderedObservers/OrderedObservers.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/basic/American.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/basic/American.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/basic/Experiment.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/basic/Experiment.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/basic/MixedObservers.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/basic/MixedObservers.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/basic/MixedObserversTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/basic/MixedObserversTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/basic/ScientificExperiment.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/basic/ScientificExperiment.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/executor/CustomExecutor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/executor/CustomExecutor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/executor/FireAsyncWithCustomExecutorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/executor/FireAsyncWithCustomExecutorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/executor/Message.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/executor/Message.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/executor/MessageObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/executor/MessageObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/handlingExceptions/MultipleExceptionsInObserversNotificationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/handlingExceptions/MultipleExceptionsInObserversNotificationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/handlingExceptions/NewYorkRadioStation.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/handlingExceptions/NewYorkRadioStation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/handlingExceptions/ParisRadioStation.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/handlingExceptions/ParisRadioStation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/handlingExceptions/PragueRadioStation.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/handlingExceptions/PragueRadioStation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/handlingExceptions/RadioMessage.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/async/handlingExceptions/RadioMessage.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/broken/validation/ambiguous/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/broken/validation/ambiguous/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/broken/validation/ambiguous/Cow.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/broken/validation/ambiguous/Cow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/broken/validation/ambiguous/Observer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/broken/validation/ambiguous/Observer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/broken/validation/ambiguous/ObserverMethodParameterInjectionValidationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/broken/validation/ambiguous/ObserverMethodParameterInjectionValidationTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/broken/validation/unsatisfied/Observer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/broken/validation/unsatisfied/Observer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/broken/validation/unsatisfied/ObserverMethodParameterInjectionValidationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/broken/validation/unsatisfied/ObserverMethodParameterInjectionValidationTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/checkedException/CheckedExceptionWrappedTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/checkedException/CheckedExceptionWrappedTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/checkedException/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/checkedException/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/checkedException/TeaCupPomeranian.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/checkedException/TeaCupPomeranian.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/conditional/AsyncConditionalEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/conditional/AsyncConditionalEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/conditional/AsyncConditionalObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/conditional/AsyncConditionalObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/conditional/ConditionalEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/conditional/ConditionalEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/conditional/ConditionalObserverTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/conditional/ConditionalObserverTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/conditional/RecluseSpider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/conditional/RecluseSpider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/conditional/Spun.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/conditional/Spun.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/conditional/Tarantula.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/conditional/Tarantula.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/conditional/TarantulaEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/conditional/TarantulaEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/conditional/Web.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/conditional/Web.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/conditional/WidowSpider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/conditional/WidowSpider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/AbstractEggObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/AbstractEggObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/Egg.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/Egg.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/ObserverInheritanceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/ObserverInheritanceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/ConditionalEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/ConditionalEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/ConditionalObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/ConditionalObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/DisobedientDog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/DisobedientDog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/EventPayload.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/EventPayload.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/IntegerObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/IntegerObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/LargeDog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/LargeDog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/Number.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/Number.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/ObserverMethodTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/ObserverMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/ShowDog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/ShowDog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/SmallDog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/SmallDog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/StockPrice.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/StockPrice.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/StockWatcher.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/StockWatcher.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/TransactionalObservers.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/method/TransactionalObservers.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/param/modification/Counter.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/param/modification/Counter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015 Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/param/modification/CounterObserver01.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/param/modification/CounterObserver01.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015 Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/param/modification/CounterObserver02.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/param/modification/CounterObserver02.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015 Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/param/modification/SyncEventModificationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/param/modification/SyncEventModificationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015 Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/EventObserverOrderingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/EventObserverOrderingTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/MoonActivity.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/MoonActivity.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/MoonObservers.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/MoonObservers.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/Moonrise.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/Moonrise.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/Sunrise.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/Sunrise.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/SunriseObservers.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/SunriseObservers.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/Sunset.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/Sunset.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/SunsetObservers.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/SunsetObservers.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/contextLifecycleEvent/ApplicationContextLifecycleEventObserverOrderingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/contextLifecycleEvent/ApplicationContextLifecycleEventObserverOrderingTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/contextLifecycleEvent/ApplicationScopedObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/contextLifecycleEvent/ApplicationScopedObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/AirConditioner.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/AirConditioner.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/BatteryEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/BatteryEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/BullTerrier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/BullTerrier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/Cloud.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/Cloud.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/DisabledObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/DisabledObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/DiskSpaceEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/DiskSpaceEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/Ghost.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/Ghost.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/MultiBindingEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/MultiBindingEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/NotEnabled.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/NotEnabled.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/Pomeranian.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/Pomeranian.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/PriviledgedObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/PriviledgedObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/ResolveEventObserversTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/ResolveEventObserversTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/Role.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/Role.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/RoleBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/RoleBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/Secret.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/Secret.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/SimpleEventType.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/SimpleEventType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/SystemMonitor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/SystemMonitor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/TameAnnotationLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/TameAnnotationLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/Temperature.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/Temperature.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/Thermostat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/Thermostat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/User.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/User.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/runtimeException/ObserverExceptionRethrownTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/runtimeException/ObserverExceptionRethrownTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/runtimeException/TeaCupPomeranian.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/runtimeException/TeaCupPomeranian.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/wildcardAndTypeVariable/Behavior.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/wildcardAndTypeVariable/Behavior.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/wildcardAndTypeVariable/BostonTerrier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/wildcardAndTypeVariable/BostonTerrier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/wildcardAndTypeVariable/ObjectList.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/wildcardAndTypeVariable/ObjectList.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/wildcardAndTypeVariable/ObserverMethodWithParametertizedTypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/wildcardAndTypeVariable/ObserverMethodWithParametertizedTypeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/parameterized/AbstractParameterizedObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/parameterized/AbstractParameterizedObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/parameterized/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/parameterized/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/parameterized/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/parameterized/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/parameterized/Blah.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/parameterized/Blah.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/parameterized/EventObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/parameterized/EventObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/parameterized/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/parameterized/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/parameterized/Fooable.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/parameterized/Fooable.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/parameterized/IntegerListObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/parameterized/IntegerListObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/parameterized/ParameterizedEventTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/parameterized/ParameterizedEventTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/parameterized/StringListObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/parameterized/StringListObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/binding/BindingTypeA.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/binding/BindingTypeA.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/binding/BindingTypeABinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/binding/BindingTypeABinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/binding/BindingTypeB.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/binding/BindingTypeB.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/binding/BindingTypeBBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/binding/BindingTypeBBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/binding/BindingTypeC.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/binding/BindingTypeC.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/binding/BindingTypeCBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/binding/BindingTypeCBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/binding/DuplicateBindingTypesWhenResolvingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/binding/DuplicateBindingTypesWhenResolvingTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/binding/ResolvingChecksBindingTypeMembersTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/binding/ResolvingChecksBindingTypeMembersTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/nonbinding/AnimalStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/nonbinding/AnimalStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/nonbinding/AnimalStereotypeAnnotationLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/nonbinding/AnimalStereotypeAnnotationLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/nonbinding/NonBindingTypesWhenResolvingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/nonbinding/NonBindingTypesWhenResolvingTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/AbstractObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/AbstractObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/Box.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/Box.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/CheckTypeParametersWhenResolvingObserversTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/CheckTypeParametersWhenResolvingObserversTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/ChecksEventTypeWhenResolvingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/ChecksEventTypeWhenResolvingTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/Dog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/Dog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/DogObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/DogObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/Duck.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/Duck.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/FooObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/FooObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/Qux.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/Qux.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/RawTypeObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/RawTypeObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/TypeVariableObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/TypeVariableObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/UnusedEventType.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/UnusedEventType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/WildcardObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/resolve/typeWithParameters/WildcardObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/select/AlarmSystem.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/select/AlarmSystem.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/select/BreakInEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/select/BreakInEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/select/NotABindingType.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/select/NotABindingType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/select/SecurityEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/select/SecurityEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/select/SecurityEvent_Illegal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/select/SecurityEvent_Illegal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/select/SecuritySensor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/select/SecuritySensor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/select/SelectEventTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/select/SelectEventTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/select/SystemTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/select/SystemTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/select/Violent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/select/Violent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/AlternativeAvailabilityTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/AlternativeAvailabilityTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Bird.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Bird.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/BirdProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/BirdProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Cat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Cat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/CatProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/CatProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Chicken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Chicken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Dog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Dog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/EnabledAlternativeStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/EnabledAlternativeStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/EnabledSheepProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/EnabledSheepProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Horse.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Horse.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/NotEnabledAlternativeStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/NotEnabledAlternativeStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/NotEnabledSheepProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/NotEnabledSheepProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Sheep.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Sheep.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Snake.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Snake.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/SnakeProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/SnakeProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Wild.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/Wild.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/broken/incorrect/name/DummyBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/broken/incorrect/name/DummyBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/broken/incorrect/name/NoClassWithSpecifiedNameTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/broken/incorrect/name/NoClassWithSpecifiedNameTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/broken/incorrect/name/stereotype/DummyAnnotation.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/broken/incorrect/name/stereotype/DummyAnnotation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/broken/incorrect/name/stereotype/NoAnnotationWithSpecifiedNameTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/broken/incorrect/name/stereotype/NoAnnotationWithSpecifiedNameTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/broken/not/alternative/Cat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/broken/not/alternative/Cat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/broken/not/alternative/ClassIsNotAlternativeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/broken/not/alternative/ClassIsNotAlternativeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/broken/not/alternative/stereotype/ClassIsNotAlternativeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/broken/not/alternative/stereotype/ClassIsNotAlternativeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/broken/not/alternative/stereotype/Mock.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/broken/not/alternative/stereotype/Mock.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/broken/same/type/twice/Cat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/broken/same/type/twice/Cat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/broken/same/type/twice/Dog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/broken/same/type/twice/Dog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/broken/same/type/twice/SameTypeListedTwiceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/broken/same/type/twice/SameTypeListedTwiceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/selection/stereotype/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/selection/stereotype/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/selection/stereotype/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/selection/stereotype/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/selection/stereotype/SelectedBeanWithUnselectedStereotypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/selection/stereotype/SelectedBeanWithUnselectedStereotypeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/selection/stereotype/UnselectedStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/selection/stereotype/UnselectedStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/veto/AlternativeConsumerProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/veto/AlternativeConsumerProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/veto/AlternativeConsumerStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/veto/AlternativeConsumerStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/veto/Consumer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/veto/Consumer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/veto/MockPaymentProcessorImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/veto/MockPaymentProcessorImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/veto/PaymentProcessor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/veto/PaymentProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/veto/PaymentProcessorImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/veto/PaymentProcessorImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/veto/VetoedAlternativeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/veto/VetoedAlternativeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/veto/VetoingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/alternative/veto/VetoingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/AfterBeanDiscoveryObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/AfterBeanDiscoveryObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/AnotherSessionBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/AnotherSessionBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/ContextDestroysBeansTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/ContextDestroysBeansTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/ContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/ContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/DestroyForSameCreationalContext2Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/DestroyForSameCreationalContext2Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/DestroyForSameCreationalContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/DestroyForSameCreationalContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/DestroyedInstanceReturnedByGetTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/DestroyedInstanceReturnedByGetTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/DummyContext.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/DummyContext.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/DummyScoped.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/DummyScoped.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/GetFromContextualTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/GetFromContextualTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/GetOnInactiveContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/GetOnInactiveContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/GetWithNoCreationalContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/GetWithNoCreationalContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/MyContextual.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/MyContextual.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/MySessionBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/MySessionBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/NormalContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/NormalContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/SimpleBeanA.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/SimpleBeanA.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/SimpleBeanB.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/SimpleBeanB.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/SimpleBeanZ.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/SimpleBeanZ.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/Unregistered.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/Unregistered.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/alterable/AbstractComponent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/alterable/AbstractComponent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/alterable/AlterableContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/alterable/AlterableContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/alterable/CustomContext.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/alterable/CustomContext.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/alterable/CustomScopeExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/alterable/CustomScopeExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/alterable/CustomScoped.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/alterable/CustomScoped.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/alterable/CustomScopedComponent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/alterable/CustomScopedComponent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/dependent/DependentContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/dependent/DependentContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2022, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/dependent/Fox.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/dependent/Fox.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/dependent/FoxProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/dependent/FoxProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/dependent/FoxRun.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/dependent/FoxRun.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/dependent/Pet.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/dependent/Pet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/dependent/SensitiveFox.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/dependent/SensitiveFox.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Big.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Big.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/City.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/City.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/CityBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/CityBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/CityProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/CityProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/CityProducer2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/CityProducer2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Generator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Generator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/HelsinkiNonSerializable.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/HelsinkiNonSerializable.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Hyvinkaa.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Hyvinkaa.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Joensuu.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Joensuu.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Jyvaskyla.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Jyvaskyla.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Kajaani.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Kajaani.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Kokkola.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Kokkola.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/KokkolaInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/KokkolaInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/NumberConsumer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/NumberConsumer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/PassivatingContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/PassivatingContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/ProducedInteger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/ProducedInteger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Record.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Record.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/RecordProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/RecordProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Salo_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Salo_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/SerializableCity.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/SerializableCity.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/SerializableCityConsumer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/SerializableCityConsumer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Sleeping.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Sleeping.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Sysma.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Sysma.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Television.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Television.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/TelevisionProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/TelevisionProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Violation.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Violation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Wheat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/Wheat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/WheatProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/WheatProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/Hamina_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/Hamina_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/NonPassivationManagedBeanHasPassivatingScopeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/NonPassivationManagedBeanHasPassivatingScopeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/constructor/NonPassivatingConstructorParamTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/constructor/NonPassivatingConstructorParamTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/constructor/Vantaa_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/constructor/Vantaa_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/constructor/Violation.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/constructor/Violation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/decorator/MaarianhaminaDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/decorator/MaarianhaminaDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/decorator/Maarianhamina_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/decorator/Maarianhamina_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/decorator/ManagedBeanWithNonPassivatingDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/decorator/ManagedBeanWithNonPassivatingDecoratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/decorator/field/CityDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/decorator/field/CityDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/decorator/field/CityInterface.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/decorator/field/CityInterface.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/decorator/field/DecoratorWithNonPassivatingInjectedFieldTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/decorator/field/DecoratorWithNonPassivatingInjectedFieldTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/decorator/field/NonPassivating.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/decorator/field/NonPassivating.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/decorator/field/UnderwaterCity.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/decorator/field/UnderwaterCity.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/field/NonPassivatingInjectedFieldTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/field/NonPassivatingInjectedFieldTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/field/Vantaa_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/field/Vantaa_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/field/Violation.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/field/Violation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/initializer/NonPassivatingInitParamTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/initializer/NonPassivatingInitParamTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/initializer/Vantaa_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/initializer/Vantaa_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/initializer/Violation.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/initializer/Violation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/interceptor/Interceptor_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/interceptor/Interceptor_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/interceptor/Kokkola_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/interceptor/Kokkola_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/interceptor/ManagedBeanWithNonSerializableInterceptorClassTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/interceptor/ManagedBeanWithNonSerializableInterceptorClassTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/interceptor/field/BakedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/interceptor/field/BakedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/interceptor/field/BakedBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/interceptor/field/BakedBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/interceptor/field/BrokenInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/interceptor/field/BrokenInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/interceptor/field/InterceptorType.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/interceptor/field/InterceptorType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/interceptor/field/PassivationCapableBeanWithNonPassivatingInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/interceptor/field/PassivationCapableBeanWithNonPassivatingInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/interceptor/field/Violation.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/interceptor/field/Violation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/interceptor/field/ViolationProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/interceptor/field/ViolationProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/field/managed/Broken_Record.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/field/managed/Broken_Record.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/field/managed/FooScoped.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/field/managed/FooScoped.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/field/managed/NonPassivationCapableProducerFieldTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/field/managed/NonPassivationCapableProducerFieldTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/field/managed/RecordProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/field/managed/RecordProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/field/managed/dependent/British.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/field/managed/dependent/British.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/field/managed/dependent/ConstructorInjectionCorralBroken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/field/managed/dependent/ConstructorInjectionCorralBroken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/field/managed/dependent/Corral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/field/managed/dependent/Corral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/field/managed/dependent/Cow.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/field/managed/dependent/Cow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/field/managed/dependent/CowProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/field/managed/dependent/CowProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/field/managed/dependent/FieldInjectionCorralBroken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/field/managed/dependent/FieldInjectionCorralBroken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/field/managed/dependent/ManagedBeanWithIllegalDependencyTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/field/managed/dependent/ManagedBeanWithIllegalDependencyTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/field/managed/dependent/SetterInjectionCorralBroken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/field/managed/dependent/SetterInjectionCorralBroken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/Broken_Record.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/Broken_Record.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/NonPassivationCapableProducerMethodTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/NonPassivationCapableProducerMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/RecordProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/RecordProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/dependent/British.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/dependent/British.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/dependent/ConstructorInjectionCorralBroken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/dependent/ConstructorInjectionCorralBroken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/dependent/Cow.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/dependent/Cow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/dependent/CowProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/dependent/CowProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/dependent/FieldInjectionCorralBroken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/dependent/FieldInjectionCorralBroken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/dependent/Herd.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/dependent/Herd.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/dependent/ManagedBeanWithIllegalDependencyTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/dependent/ManagedBeanWithIllegalDependencyTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/dependent/ProducerMethodParamInjectionCorralBroken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/dependent/ProducerMethodParamInjectionCorralBroken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/dependent/Ranch.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/dependent/Ranch.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/dependent/SetterInjectionCorralBroken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/broken/producer/method/managed/dependent/SetterInjectionCorralBroken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/custom/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/custom/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/custom/BarExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/custom/BarExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/custom/ClusterContext.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/custom/ClusterContext.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/custom/ClusterScoped.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/custom/ClusterScoped.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/custom/ClusteringExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/custom/ClusteringExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/custom/CustomPassivatingScopeCalledWithSerializableParametersTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/custom/CustomPassivatingScopeCalledWithSerializableParametersTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/custom/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/custom/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/dependency/builtin/Boss.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/dependency/builtin/Boss.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/dependency/builtin/BuiltinBeanPassivationDependencyTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/dependency/builtin/BuiltinBeanPassivationDependencyTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/dependency/builtin/Hammer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/dependency/builtin/Hammer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/dependency/builtin/Inspector.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/dependency/builtin/Inspector.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/dependency/builtin/InspectorAssistant.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/dependency/builtin/InspectorAssistant.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/dependency/builtin/Worker.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/dependency/builtin/Worker.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/injection/point/Meal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/injection/point/Meal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/injection/point/PassivationCapableInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/injection/point/PassivationCapableInjectionPointTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/injection/point/Spoon.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/injection/point/Spoon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/producer/AnswerFieldProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/producer/AnswerFieldProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/producer/AnswerMethodProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/producer/AnswerMethodProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/producer/AnswerToTheUltimateQuestion.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/producer/AnswerToTheUltimateQuestion.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/producer/ProducerMethodWithPrimitiveReturnTypePassivationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/producer/ProducerMethodWithPrimitiveReturnTypePassivationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/producer/ProducerWithPrimitiveFieldTypePassivationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/producer/ProducerWithPrimitiveFieldTypePassivationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/producer/Universe.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/producer/Universe.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/transientreference/Meal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/transientreference/Meal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/transientreference/Spoon.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/transientreference/Spoon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/transientreference/TransientReferenceParameterTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/transientreference/TransientReferenceParameterTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/validation/DecoratorWithNonPassivationCapableDependenciesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/validation/DecoratorWithNonPassivationCapableDependenciesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/validation/Engine.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/validation/Engine.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/validation/EnginePowered.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/validation/EnginePowered.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/validation/EnginePoweredInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/validation/EnginePoweredInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/validation/Ferry.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/validation/Ferry.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/validation/InterceptorWithNonPassivationCapableDependenciesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/validation/InterceptorWithNonPassivationCapableDependenciesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/validation/Vessel.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/validation/Vessel.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/validation/VesselDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/context/passivating/validation/VesselDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/AbstractDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/AbstractDecoratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/beanmanager/BeanManagerDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/beanmanager/BeanManagerDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/beanmanager/BeanManagerDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/beanmanager/BeanManagerDecoratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/beanmanager/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/beanmanager/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/beanmanager/FooObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/beanmanager/FooObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/conversation/BuiltinConversationDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/conversation/BuiltinConversationDecoratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/conversation/ConversationDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/conversation/ConversationDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/conversation/ConversationObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/conversation/ConversationObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/conversation/Duck.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/conversation/Duck.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/BuiltinEventDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/BuiltinEventDecoratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/CharSequenceEventDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/CharSequenceEventDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/FooEventDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/FooEventDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/Observer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/Observer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/StringEventDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/StringEventDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/complex/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/complex/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/complex/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/complex/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/complex/ComplexEventDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/complex/ComplexEventDecoratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/complex/ObserverMethodComparator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/complex/ObserverMethodComparator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/complex/Observers.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/complex/Observers.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/complex/Ordered.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/complex/Ordered.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/complex/OrderedEventDeliveryDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/complex/OrderedEventDeliveryDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/complex/OrderedEventDeliveryExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/complex/OrderedEventDeliveryExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/complex/Payload.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/event/complex/Payload.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/injectionpoint/BuiltinInjectionPointDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/injectionpoint/BuiltinInjectionPointDecoratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/injectionpoint/Company.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/injectionpoint/Company.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/injectionpoint/Fuse.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/injectionpoint/Fuse.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/injectionpoint/InjectionPointDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/injectionpoint/InjectionPointDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/instance/BuiltinInstanceDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/instance/BuiltinInstanceDecoratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/instance/Mule.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/instance/Mule.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/instance/MuleInstanceDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/builtin/instance/MuleInstanceDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/context/dependent/DependentContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/context/dependent/DependentContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/context/dependent/Interior.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/context/dependent/Interior.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/context/dependent/InteriorDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/context/dependent/InteriorDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/context/dependent/InteriorRoom.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/context/dependent/InteriorRoom.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/context/dependent/Room.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/context/dependent/Room.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/context/dependent/RoomBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/context/dependent/RoomBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/AfterBeanDiscoveryObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/AfterBeanDiscoveryObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/Bus.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/Bus.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/CustomDecoratorImplementation.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/CustomDecoratorImplementation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/CustomDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/CustomDecoratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/Vehicle.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/Vehicle.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/VehicleDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/VehicleDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/finalBeanClass/AfterBeanDiscoveryObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/finalBeanClass/AfterBeanDiscoveryObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/finalBeanClass/Bus.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/finalBeanClass/Bus.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/finalBeanClass/BusGarage.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/finalBeanClass/BusGarage.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/finalBeanClass/CustomDecoratorImplementation.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/finalBeanClass/CustomDecoratorImplementation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/finalBeanClass/CustomDecoratorMatchingBeanWithFinalClassTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/finalBeanClass/CustomDecoratorMatchingBeanWithFinalClassTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/finalBeanClass/Truck.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/finalBeanClass/Truck.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/finalBeanClass/Vehicle.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/finalBeanClass/Vehicle.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/finalBeanClass/VehicleDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/finalBeanClass/VehicleDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/nodelegateinjectionpoint/AfterBeanDiscoveryObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/nodelegateinjectionpoint/AfterBeanDiscoveryObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/nodelegateinjectionpoint/Bus.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/nodelegateinjectionpoint/Bus.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/nodelegateinjectionpoint/CustomDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/nodelegateinjectionpoint/CustomDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/nodelegateinjectionpoint/CustomDecoratorWithNoDelegateInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/nodelegateinjectionpoint/CustomDecoratorWithNoDelegateInjectionPointTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/nodelegateinjectionpoint/Vehicle.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/nodelegateinjectionpoint/Vehicle.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/nodelegateinjectionpoint/VehicleDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/nodelegateinjectionpoint/VehicleDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/toomanydelegateinjectionpoints/AfterBeanDiscoveryObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/toomanydelegateinjectionpoints/AfterBeanDiscoveryObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/toomanydelegateinjectionpoints/Bus.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/toomanydelegateinjectionpoints/Bus.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/toomanydelegateinjectionpoints/CustomDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/toomanydelegateinjectionpoints/CustomDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/toomanydelegateinjectionpoints/CustomDecoratorWithTooManyDelegateInjectionPointsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/toomanydelegateinjectionpoints/CustomDecoratorWithTooManyDelegateInjectionPointsTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/toomanydelegateinjectionpoints/Vehicle.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/toomanydelegateinjectionpoints/Vehicle.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/toomanydelegateinjectionpoints/VehicleDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/custom/broken/toomanydelegateinjectionpoints/VehicleDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/AbstractFooDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/AbstractFooDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/Account.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/Account.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/BankAccount.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/BankAccount.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/BazDecorator1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/BazDecorator1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/BazDecorator2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/BazDecorator2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/Bazt.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/Bazt.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/BaztImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/BaztImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/Boo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/Boo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/ChargeDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/ChargeDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/CowShed.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/CowShed.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/DecoratorDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/DecoratorDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/Field.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/Field.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/FieldDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/FieldDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/FieldImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/FieldImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/FooBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/FooBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/FooBarImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/FooBarImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/FooDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/FooDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/Logger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/Logger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/Meta.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/Meta.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/MockLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/MockLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/NonMeta.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/NonMeta.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/TimestampLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/TimestampLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/decoratorListedTwiceInBeansXml/DecoratorListedTwiceInBeansXmlTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/decoratorListedTwiceInBeansXml/DecoratorListedTwiceInBeansXmlTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/decoratorListedTwiceInBeansXml/Present.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/decoratorListedTwiceInBeansXml/Present.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/decoratorListedTwiceInBeansXml/PresentDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/decoratorListedTwiceInBeansXml/PresentDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/enabledDecoratorIsNotDecorator/EnabledDecoratorNotADecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/enabledDecoratorIsNotDecorator/EnabledDecoratorNotADecoratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/enabledDecoratorIsNotDecorator/Logger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/enabledDecoratorIsNotDecorator/Logger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/enabledDecoratorIsNotDecorator/MockLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/enabledDecoratorIsNotDecorator/MockLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/enabledDecoratorIsNotDecorator/TimestampLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/enabledDecoratorIsNotDecorator/TimestampLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/finalBeanClass/FinalBeanClassTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/finalBeanClass/FinalBeanClassTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/finalBeanClass/Logger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/finalBeanClass/Logger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/finalBeanClass/MockLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/finalBeanClass/MockLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/finalBeanClass/TimestampLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/finalBeanClass/TimestampLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/finalBeanMethod/FinalBeanMethodTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/finalBeanMethod/FinalBeanMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/finalBeanMethod/Logger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/finalBeanMethod/Logger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/finalBeanMethod/MockLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/finalBeanMethod/MockLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/finalBeanMethod/TimestampLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/finalBeanMethod/TimestampLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/invalidAbstractMethodOnDecorator/Account.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/invalidAbstractMethodOnDecorator/Account.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/invalidAbstractMethodOnDecorator/BankAccount.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/invalidAbstractMethodOnDecorator/BankAccount.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/invalidAbstractMethodOnDecorator/DecoratorWithInvalidAbstractMethodTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/invalidAbstractMethodOnDecorator/DecoratorWithInvalidAbstractMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/invalidAbstractMethodOnDecorator/ThiefDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/invalidAbstractMethodOnDecorator/ThiefDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/multipleDelegateInjectionPoints/Logger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/multipleDelegateInjectionPoints/Logger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/multipleDelegateInjectionPoints/MockLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/multipleDelegateInjectionPoints/MockLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/multipleDelegateInjectionPoints/MultipleDelegateInjectionPointsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/multipleDelegateInjectionPoints/MultipleDelegateInjectionPointsTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/multipleDelegateInjectionPoints/TimestampLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/multipleDelegateInjectionPoints/TimestampLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/noDelegateInjectionPoints/Logger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/noDelegateInjectionPoints/Logger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/noDelegateInjectionPoints/MockLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/noDelegateInjectionPoints/MockLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/noDelegateInjectionPoints/NoDelegateInjectionPointsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/noDelegateInjectionPoints/NoDelegateInjectionPointsTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/noDelegateInjectionPoints/TimestampLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/noDelegateInjectionPoints/TimestampLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nodecoratedtypes/DecoratorWithNoDecoratedTypes1Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nodecoratedtypes/DecoratorWithNoDecoratedTypes1Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nodecoratedtypes/DecoratorWithNoDecoratedTypes2Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nodecoratedtypes/DecoratorWithNoDecoratedTypes2Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nodecoratedtypes/DecoratorWithNoDecoratedTypes3Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nodecoratedtypes/DecoratorWithNoDecoratedTypes3Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nodecoratedtypes/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nodecoratedtypes/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nodecoratedtypes/FooDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nodecoratedtypes/FooDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nodecoratedtypes/Glue.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nodecoratedtypes/Glue.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nodecoratedtypes/GlueDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nodecoratedtypes/GlueDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nodecoratedtypes/GlueDecoratorExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nodecoratedtypes/GlueDecoratorExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nodecoratedtypes/NonExisting.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nodecoratedtypes/NonExisting.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nodecoratedtypes/SerializableDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nodecoratedtypes/SerializableDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nonDecoratorWithDecorates/ChristmasTree.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nonDecoratorWithDecorates/ChristmasTree.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nonDecoratorWithDecorates/Elf.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nonDecoratorWithDecorates/Elf.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nonDecoratorWithDecorates/NonDecoratorWithDecoratesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nonDecoratorWithDecorates/NonDecoratorWithDecoratesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nonDependent/FooService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nonDependent/FooService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nonDependent/FooServiceDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nonDependent/FooServiceDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nonDependent/NonDependentDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nonDependent/NonDependentDecoratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nonExistantClassInBeansXml/DummyBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nonExistantClassInBeansXml/DummyBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nonExistantClassInBeansXml/NonExistantDecoratorClassInBeansXmlTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/nonExistantClassInBeansXml/NonExistantDecoratorClassInBeansXmlTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/notAllDecoratedTypesImplemented/EnhancedLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/notAllDecoratedTypesImplemented/EnhancedLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/notAllDecoratedTypesImplemented/Logger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/notAllDecoratedTypesImplemented/Logger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/notAllDecoratedTypesImplemented/MockLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/notAllDecoratedTypesImplemented/MockLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/notAllDecoratedTypesImplemented/NotAllDecoratedTypesImplementedTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/notAllDecoratedTypesImplemented/NotAllDecoratedTypesImplementedTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/notAllDecoratedTypesImplemented/TimestampLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/notAllDecoratedTypesImplemented/TimestampLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/notAllDecoratedTypesImplemented/parameterized/EnhancedLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/notAllDecoratedTypesImplemented/parameterized/EnhancedLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/notAllDecoratedTypesImplemented/parameterized/Logger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/notAllDecoratedTypesImplemented/parameterized/Logger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/notAllDecoratedTypesImplemented/parameterized/MockLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/notAllDecoratedTypesImplemented/parameterized/MockLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/notAllDecoratedTypesImplemented/parameterized/TimestampLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/notAllDecoratedTypesImplemented/parameterized/TimestampLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/notAllDecoratedTypesImplemented/parameterized/TypeParametersNotTheSameTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/notAllDecoratedTypesImplemented/parameterized/TypeParametersNotTheSameTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/observer/ApplicationLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/observer/ApplicationLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/observer/DecoratorWithAsyncObserverMethodTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/observer/DecoratorWithAsyncObserverMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/observer/DecoratorWithObserverMethodTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/observer/DecoratorWithObserverMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/observer/FilesystemLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/observer/FilesystemLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/observer/FooPayload.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/observer/FooPayload.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/observer/Logger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/observer/Logger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/observer/MockLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/observer/MockLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/parameterizedTypesWithDifferentTypeParameters/DifferentTypeParametersTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/parameterizedTypesWithDifferentTypeParameters/DifferentTypeParametersTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/parameterizedTypesWithDifferentTypeParameters/Radio.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/parameterizedTypesWithDifferentTypeParameters/Radio.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/parameterizedTypesWithDifferentTypeParameters/RadioDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/parameterizedTypesWithDifferentTypeParameters/RadioDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/parameterizedTypesWithDifferentTypeParameters/RadioProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/broken/parameterizedTypesWithDifferentTypeParameters/RadioProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateConstructor/CowShed.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateConstructor/CowShed.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateConstructor/DelegateInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateConstructor/DelegateInjectionPointTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateConstructor/Logger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateConstructor/Logger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateConstructor/MockLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateConstructor/MockLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateConstructor/TimestampLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateConstructor/TimestampLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateField/CowShed.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateField/CowShed.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateField/DelegateFieldInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateField/DelegateFieldInjectionPointTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateField/Logger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateField/Logger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateField/MockLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateField/MockLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateField/TimestampLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateField/TimestampLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateInitializerMethod/CowShed.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateInitializerMethod/CowShed.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateInitializerMethod/DelegateInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateInitializerMethod/DelegateInjectionPointTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateInitializerMethod/Logger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateInitializerMethod/Logger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateInitializerMethod/MockLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateInitializerMethod/MockLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateInitializerMethod/TimestampLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/inject/delegateInitializerMethod/TimestampLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/producer/Bank.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/producer/Bank.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/producer/BankAccount.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/producer/BankAccount.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/producer/ChargeDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/producer/ChargeDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/producer/DecoratorNotAppliedToResultOfProducerTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/producer/DecoratorNotAppliedToResultOfProducerTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/producer/DurableAccount.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/producer/DurableAccount.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/producer/ShortTermAccount.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/producer/ShortTermAccount.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/producer/Synthetic.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/producer/Synthetic.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/types/DelegateTypeImplementsParameterizedDecoratedTypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/types/DelegateTypeImplementsParameterizedDecoratedTypeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/types/EnhancedLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/types/EnhancedLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/types/Logger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/types/Logger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/types/MockLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/types/MockLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/types/TimestampLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/definition/types/TimestampLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/interceptor/DecoratorAndInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/interceptor/DecoratorAndInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/interceptor/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/interceptor/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/interceptor/FooBinding1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/interceptor/FooBinding1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/interceptor/FooBinding2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/interceptor/FooBinding2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/interceptor/FooDecorator1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/interceptor/FooDecorator1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/interceptor/FooDecorator2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/interceptor/FooDecorator2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/interceptor/FooInterceptor1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/interceptor/FooInterceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/interceptor/FooInterceptor2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/interceptor/FooInterceptor2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/interceptor/FooStuff.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/interceptor/FooStuff.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/BarDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/BarDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/BarImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/BarImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/CowShed.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/CowShed.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/DecoratorInvocationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/DecoratorInvocationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/FooDecorator1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/FooDecorator1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/FooDecorator2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/FooDecorator2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/FooImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/FooImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/Logger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/Logger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/MockLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/MockLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/TimestampLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/TimestampLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/observer/DecoratorInvocationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/observer/DecoratorInvocationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/observer/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/observer/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/observer/Observer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/observer/Observer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/observer/ObserverDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/observer/ObserverDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/observer/ObserverImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/observer/ObserverImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/producer/method/DecoratorInvocationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/producer/method/DecoratorInvocationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/producer/method/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/producer/method/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/producer/method/Producer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/producer/method/Producer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/producer/method/ProducerDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/producer/method/ProducerDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/producer/method/ProducerImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/invocation/producer/method/ProducerImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/lookup/clientProxy/unproxyable/decorator/DecoratoredBeanProxyTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/lookup/clientProxy/unproxyable/decorator/DecoratoredBeanProxyTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/lookup/clientProxy/unproxyable/decorator/Fish.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/lookup/clientProxy/unproxyable/decorator/Fish.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/lookup/clientProxy/unproxyable/decorator/MarineDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/lookup/clientProxy/unproxyable/decorator/MarineDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/lookup/clientProxy/unproxyable/decorator/TestBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/lookup/clientProxy/unproxyable/decorator/TestBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/lookup/clientProxy/unproxyable/decorator/Tuna.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/lookup/clientProxy/unproxyable/decorator/Tuna.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/BarDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/BarDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/BarImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/BarImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/BazDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/BazDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/BazImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/BazImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/Corge.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/Corge.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/CorgeDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/CorgeDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/CorgeDecorator2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/CorgeDecorator2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/CorgeImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/CorgeImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/CorgeImpl2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/CorgeImpl2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/Cow.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/Cow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/DecoratedType.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/DecoratedType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/DecoratorResolutionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/DecoratorResolutionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/FemaleFresianCow.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/FemaleFresianCow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/FooDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/FooDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/FooImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/FooImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/FooObjectDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/FooObjectDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/FresianCow.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/FresianCow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/Garply.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/Garply.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/GarplyDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/GarplyDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/GarplyImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/GarplyImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/Grault.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/Grault.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/GraultExtendsDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/GraultExtendsDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/GraultIntegerImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/GraultIntegerImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/GraultSuperDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/GraultSuperDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/Qux.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/Qux.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/QuxDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/QuxDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/QuxImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/QuxImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/QuxListDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/QuxListDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/QuxListImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/decorators/resolution/QuxListImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/AfterBeanDiscoveryObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/AfterBeanDiscoveryObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/AlternativeSomeBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/AlternativeSomeBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/AlternativeStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/AlternativeStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/CustomBeanImplementationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/CustomBeanImplementationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/CustomInjectionPoint.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/CustomInjectionPoint.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/FooBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/FooBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/House.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/House.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/IntegerBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/IntegerBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/Passivable.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/Passivable.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/PassivableLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/PassivableLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/PassivationCapableBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/PassivationCapableBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/SomeBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/definition/bean/custom/SomeBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Alpha.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Alpha.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Alpha2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Alpha2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Alpha3.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Alpha3.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/BeanDiscoveryTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/BeanDiscoveryTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Binding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Binding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Bravo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Bravo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Charlie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Charlie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Decorator1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Decorator1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Decorator2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Decorator2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Delta.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Delta.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Echo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Echo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/EchoNotABean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/EchoNotABean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Foxtrot.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Foxtrot.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Golf.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Golf.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Hotel.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Hotel.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/India.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/India.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Interceptor1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Interceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Interceptor2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Interceptor2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Juliet.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Juliet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/JulietNotABean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/JulietNotABean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Kilo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Kilo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/LegacyAlpha.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/LegacyAlpha.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/LegacyBravo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/LegacyBravo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/LegacyExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/LegacyExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Lima.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Lima.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Mike.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Mike.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/MyNormalContext.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/MyNormalContext.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/MyNormalScope.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/MyNormalScope.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/MyPseudoContext.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/MyPseudoContext.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/MyPseudoScope.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/MyPseudoScope.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/MyStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/MyStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/November.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/November.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Ping.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/Ping.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/ScopesExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/ScopesExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/VerifyingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/discovery/VerifyingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/Alpha.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/Alpha.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/Bravo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/Bravo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/Charlie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/Charlie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/Delta.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/Delta.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/Echo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/Echo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/ExcludeFiltersTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/ExcludeFiltersTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/Foxtrot.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/Foxtrot.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/Golf.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/Golf.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/Stubble.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/Stubble.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/VerifyingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/VerifyingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/food/Meat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/food/Meat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/haircut/Chonmage.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/haircut/Chonmage.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/mustache/Mustache.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/mustache/Mustache.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/mustache/beard/Beard.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/exclude/mustache/beard/Beard.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/initialization/ApplicationInitializationLifecycleTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/initialization/ApplicationInitializationLifecycleTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/initialization/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/initialization/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/initialization/LifecycleMonitoringExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/initialization/LifecycleMonitoringExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/trimmed/Bike.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/trimmed/Bike.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/trimmed/BikeProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/trimmed/BikeProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/trimmed/Bus.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/trimmed/Bus.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/trimmed/Car.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/trimmed/Car.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/trimmed/MotorizedVehicle.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/trimmed/MotorizedVehicle.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/trimmed/Popular.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/trimmed/Popular.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/trimmed/Segway.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/trimmed/Segway.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/trimmed/TestExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/trimmed/TestExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/trimmed/TrimmedBeanArchiveTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/deployment/trimmed/TrimmedBeanArchiveTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/Delivery.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/Delivery.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/EventTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/EventTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/FarmShop.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/FarmShop.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/Shop.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/Shop.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/broken/raw/AfterBeanDiscoveryObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/broken/raw/AfterBeanDiscoveryObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/broken/raw/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/broken/raw/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/broken/raw/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/broken/raw/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/broken/raw/CustomBarBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/broken/raw/CustomBarBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/broken/raw/CustomEventInjectionPoint.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/broken/raw/CustomEventInjectionPoint.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/broken/raw/ProcessInjectionPointObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/broken/raw/ProcessInjectionPointObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/broken/raw/RawEventCustomBeanTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/broken/raw/RawEventCustomBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/broken/raw/RawEventProcessInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/broken/raw/RawEventProcessInjectionPointTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/fires/ContainerLifecycleEventDispatcher.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/fires/ContainerLifecycleEventDispatcher.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/fires/FireEventTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/fires/FireEventTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/extension/AbstractObserverNotificationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/extension/AbstractObserverNotificationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/extension/Angry.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/extension/Angry.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/extension/BeanManagerObserverNotificationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/extension/BeanManagerObserverNotificationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/extension/EventBeanObserverNotificationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/extension/EventBeanObserverNotificationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/extension/Giraffe.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/extension/Giraffe.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/extension/GiraffeObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/extension/GiraffeObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/extension/Nubian.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/extension/Nubian.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/extension/ObserverExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/extension/ObserverExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/extension/Tall.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/extension/Tall.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/priority/EventObserverOrderingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/priority/EventObserverOrderingTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/priority/MoonActivity.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/priority/MoonActivity.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/priority/MoonObservers.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/priority/MoonObservers.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/priority/Moonrise.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/priority/Moonrise.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/priority/ObserverExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/event/observer/priority/ObserverExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/AfterBeanDiscoveryObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/AfterBeanDiscoveryObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/AfterBeanDiscoveryTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/AfterBeanDiscoveryTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/Cage.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/Cage.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/Cockatoo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/Cockatoo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/Listener.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/Listener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/SuperContext.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/SuperContext.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/SuperScoped.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/SuperScoped.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/Talk.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/Talk.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/TestableObserverMethod.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/TestableObserverMethod.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/annotated/Alpha.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/annotated/Alpha.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/annotated/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/annotated/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/annotated/Bravo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/annotated/Bravo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/annotated/Charlie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/annotated/Charlie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/annotated/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/annotated/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/annotated/GetAnnotatedTypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/annotated/GetAnnotatedTypesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/annotated/ModifyingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/afterBeanDiscovery/annotated/ModifyingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/deployment/AlternativeInLibraryWithExtensionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/deployment/AlternativeInLibraryWithExtensionTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/deployment/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/deployment/Bar.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/deployment/BarAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/deployment/BarAlternative.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/deployment/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/deployment/Foo.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/deployment/NoopExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/deployment/NoopExtension.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/AlternativeMetadataTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/AlternativeMetadataTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Bill.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Bill.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Bread.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Bread.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Carrot.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Carrot.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Cheap.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Cheap.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/CheapLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/CheapLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Expensive.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Expensive.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/ExpensiveLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/ExpensiveLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Fruit.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Fruit.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Grocery.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Grocery.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/GroceryInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/GroceryInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/GroceryInterceptorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/GroceryInterceptorBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/GroceryWrapper.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/GroceryWrapper.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/ItalianFood.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/ItalianFood.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Market.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Market.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/MarketWrapper.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/MarketWrapper.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Milk.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Milk.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/NamedStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/NamedStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/ProcessAnnotatedTypeObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/ProcessAnnotatedTypeObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Sausage.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Sausage.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Shop.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Shop.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/TropicalFruit.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/TropicalFruit.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Vegetables.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Vegetables.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Water.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Water.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Yogurt.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/Yogurt.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/annotated/Android.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/annotated/Android.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/annotated/AnnotatedTypeAnnotationsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/annotated/AnnotatedTypeAnnotationsTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/annotated/Being.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/annotated/Being.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/annotated/Fate.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/annotated/Fate.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/annotated/Human.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/annotated/Human.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/annotated/InheritedQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/annotated/InheritedQualifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/annotated/Kryten.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/annotated/Kryten.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/annotated/Mortal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/annotated/Mortal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/annotated/NotInheritedQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/annotated/NotInheritedQualifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/annotated/NotInheritedStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/annotated/NotInheritedStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/annotated/ObservingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/annotated/ObservingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/annotated/Rimmer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/annotated/Rimmer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/interceptor/AlternativeMetadataInterceptorInjectionTargetTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/interceptor/AlternativeMetadataInterceptorInjectionTargetTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/interceptor/AlternativeMetadataInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/interceptor/AlternativeMetadataInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/interceptor/InterceptorExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/interceptor/InterceptorExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/interceptor/Login.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/interceptor/Login.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/interceptor/LoginInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/interceptor/LoginInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/interceptor/LoginInterceptorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/interceptor/LoginInterceptorBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/interceptor/Secured.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/alternative/metadata/interceptor/Secured.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/AbstractC.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/AbstractC.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/AlternativeMetaDataTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/AlternativeMetaDataTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/Cat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/Cat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/ClassD.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/ClassD.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/Dog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/Dog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/DogHouse.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/DogHouse.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/Felid.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/Felid.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/InterfaceA.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/InterfaceA.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/InterfaceB.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/InterfaceB.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/Mammal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/Mammal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/ProcessAnnotatedTypeObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/ProcessAnnotatedTypeObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/ProcessAnnotatedTypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/ProcessAnnotatedTypeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/TestAnnotatedType.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/TestAnnotatedType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/Type.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/Type.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/VetoedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/VetoedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/WildCat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/WildCat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/broken/processAnnotatedObserverThrowsException/Dog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/broken/processAnnotatedObserverThrowsException/Dog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/broken/processAnnotatedObserverThrowsException/ProcessAnnotatedTypeEventThrowsExceptionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/broken/processAnnotatedObserverThrowsException/ProcessAnnotatedTypeEventThrowsExceptionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/broken/processAnnotatedObserverThrowsException/ProcessAnnotatedTypeObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/broken/processAnnotatedObserverThrowsException/ProcessAnnotatedTypeObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/broken/processInjectionTargetThrowsException/Dog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/broken/processInjectionTargetThrowsException/Dog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/broken/processInjectionTargetThrowsException/InjectionTargetProcessor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/broken/processInjectionTargetThrowsException/InjectionTargetProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/broken/processInjectionTargetThrowsException/ProcessInjectionTargetEventThrowsExceptionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/broken/processInjectionTargetThrowsException/ProcessInjectionTargetEventThrowsExceptionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/AplomadoFalcon.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/AplomadoFalcon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Baby.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Baby.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/BatFalcon.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/BatFalcon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/BeeHummingbird.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/BeeHummingbird.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/BeforeBeanDiscoveryObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/BeforeBeanDiscoveryObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Bird.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Bird.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Chicken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Chicken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Desired.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Desired.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Egg.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Egg.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Falcon.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Falcon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Griffin.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Griffin.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Hen.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Hen.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Hummingbird.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Hummingbird.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Jack.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Jack.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/MetaAnnotation.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/MetaAnnotation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/OcellatedTurkey.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/OcellatedTurkey.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Phoenix.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Phoenix.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Pirate.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Pirate.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/ProcessAnnotatedTypeObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/ProcessAnnotatedTypeObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Raven.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Raven.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/RubberChicken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/RubberChicken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Sparrow.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Sparrow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Turkey.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Turkey.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Wanted.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/Wanted.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/WithAnnotationsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/WithAnnotationsTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/broken/ApplicationObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/broken/ApplicationObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/broken/ExtensionObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/broken/ExtensionObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/broken/WithAnnotationsAppliedToIllegalContainerLifecycleEventParameterTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/broken/WithAnnotationsAppliedToIllegalContainerLifecycleEventParameterTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/broken/WithAnnotationsAppliedToIllegalEventParameterTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/delivery/broken/WithAnnotationsAppliedToIllegalEventParameterTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/Apple.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/Apple.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/AppleExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/AppleExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/Fresh.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/Fresh.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/Fruit.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/Fruit.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/Juicy.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/Juicy.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/ModifyingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/ModifyingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/Orange.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/Orange.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/Pear.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/Pear.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/Plants.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/Plants.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/ProcessSyntheticAnnotatedTypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/ProcessSyntheticAnnotatedTypeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/RegisteringAnnotationExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/RegisteringAnnotationExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/RegisteringExtension1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/RegisteringExtension1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/RegisteringExtension2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/RegisteringExtension2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/RegisteringExtension3.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/RegisteringExtension3.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/TestAnnotation.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/TestAnnotation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/Vegetables.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/Vegetables.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/VerifyingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/annotated/synthetic/VerifyingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanDiscovery/event/ordering/HastilyWritten.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanDiscovery/event/ordering/HastilyWritten.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanDiscovery/event/ordering/HighQualityAndLowCostProduct.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanDiscovery/event/ordering/HighQualityAndLowCostProduct.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanDiscovery/event/ordering/LifecycleEventOrderingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanDiscovery/event/ordering/LifecycleEventOrderingTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanDiscovery/event/ordering/MassiveJugCoffee.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanDiscovery/event/ordering/MassiveJugCoffee.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanDiscovery/event/ordering/PoorWorker.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanDiscovery/event/ordering/PoorWorker.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanDiscovery/event/ordering/ProductManagement.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanDiscovery/event/ordering/ProductManagement.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/AfterBeanDiscoveryObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/AfterBeanDiscoveryObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/AnimalStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/AnimalStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/BeanManagerTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/BeanManagerTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/Cow.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/Cow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/CowBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/CowBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/DerivedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/DerivedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/Dog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/Dog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/DogHouse.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/DogHouse.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/DummyContext.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/DummyContext.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/DummyScoped.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/DummyScoped.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/InjectionPointDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/InjectionPointDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/PassivationIdTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/PassivationIdTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2008, Red Hat, Inc. and/or its affiliates, and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/SimpleBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/SimpleBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/Snake.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/Snake.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/Terrier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/Terrier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/Transactional.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/Transactional.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/UnregisteredExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/UnregisteredExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/BeanExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/BeanExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/Building.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/Building.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/Employee.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/Employee.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/FireTruck.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/FireTruck.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/Hungry.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/Hungry.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/Large.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/Large.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/Lion.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/Lion.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/Office.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/Office.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/SerializableOffice.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/SerializableOffice.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/Simple.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/Simple.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/SimpleInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/SimpleInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/SyntheticBeanTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/SyntheticBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/Tiger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/Tiger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/Vehicle.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/Vehicle.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/VehicleDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/VehicleDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/Zoo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bean/Zoo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/beanAttributes/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/beanAttributes/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/beanAttributes/CreateBeanAttributesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/beanAttributes/CreateBeanAttributesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/beanAttributes/Fish.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/beanAttributes/Fish.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/beanAttributes/InvalidBeanType.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/beanAttributes/InvalidBeanType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/beanAttributes/Landmark.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/beanAttributes/Landmark.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/beanAttributes/Mountain.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/beanAttributes/Mountain.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/beanAttributes/Natural.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/beanAttributes/Natural.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/beanAttributes/TundraStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/beanAttributes/TundraStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/beanAttributes/WaterBody.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/beanAttributes/WaterBody.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/beanAttributes/Wild.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/beanAttributes/Wild.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bootstrap/unavailable/methods/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bootstrap/unavailable/methods/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bootstrap/unavailable/methods/Transactional.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bootstrap/unavailable/methods/Transactional.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bootstrap/unavailable/methods/UnavailableMethodsDuringApplicationInitializationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bootstrap/unavailable/methods/UnavailableMethodsDuringApplicationInitializationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bootstrap/unavailable/methods/WrongExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/bootstrap/unavailable/methods/WrongExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/broken/event/ContainerLifecycleEvents.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/broken/event/ContainerLifecycleEvents.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/broken/event/FireContainerLifecycleEventTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/broken/event/FireContainerLifecycleEventTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/broken/event/FooExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/broken/event/FooExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/el/DummyExpressionFactory.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/el/DummyExpressionFactory.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/el/DummyMethodExpression.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/el/DummyMethodExpression.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/el/DummyValueExpression.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/el/DummyValueExpression.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/el/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/el/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/el/WrapExpressionFactoryTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/el/WrapExpressionFactoryTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/equivalence/interceptorbinding/InterceptorBindingEquivalenceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/equivalence/interceptorbinding/InterceptorBindingEquivalenceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/equivalence/interceptorbinding/Level.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/equivalence/interceptorbinding/Level.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/equivalence/interceptorbinding/Missile.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/equivalence/interceptorbinding/Missile.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/equivalence/interceptorbinding/MissileInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/equivalence/interceptorbinding/MissileInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/equivalence/interceptorbinding/MissileInterceptorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/equivalence/interceptorbinding/MissileInterceptorBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/equivalence/qualifier/ArmorClass.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/equivalence/qualifier/ArmorClass.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/equivalence/qualifier/Level.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/equivalence/qualifier/Level.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/equivalence/qualifier/Monster.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/equivalence/qualifier/Monster.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/equivalence/qualifier/MonsterQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/equivalence/qualifier/MonsterQualifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/equivalence/qualifier/QualifierEquivalenceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/equivalence/qualifier/QualifierEquivalenceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/equivalence/qualifier/Troll.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/equivalence/qualifier/Troll.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/injectionPoint/Book.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/injectionPoint/Book.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/injectionPoint/CreateInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/injectionPoint/CreateInjectionPointTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/injectionPoint/Fictional.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/injectionPoint/Fictional.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/injectionPoint/Library.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/injectionPoint/Library.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/injectionPoint/Magazine.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/injectionPoint/Magazine.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/injectionPoint/Monograph.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/injectionPoint/Monograph.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/injectionPoint/NotABean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/injectionPoint/NotABean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/producer/AnotherFactory.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/producer/AnotherFactory.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/producer/Factory.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/producer/Factory.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/producer/SpaceSuit.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/producer/SpaceSuit.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/producer/SyntheticProducerTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/producer/SyntheticProducerTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/producer/Toy.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/producer/Toy.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/unmanaged/Axe.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/unmanaged/Axe.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/unmanaged/Builder.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/unmanaged/Builder.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/unmanaged/Elephant.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/unmanaged/Elephant.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/unmanaged/Hammer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/unmanaged/Hammer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/unmanaged/Nail.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/unmanaged/Nail.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/unmanaged/Proboscis.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/unmanaged/Proboscis.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/unmanaged/ToolBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/unmanaged/ToolBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/unmanaged/ToolInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/unmanaged/ToolInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/unmanaged/UnmanagedInstanceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/unmanaged/UnmanagedInstanceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/unmanaged/Zoo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/unmanaged/Zoo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/unmanaged/broken/House.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/unmanaged/broken/House.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/unmanaged/broken/UnamangedInstanceIllegalStatesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/beanManager/unmanaged/broken/UnamangedInstanceIllegalStatesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/communication/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/communication/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/communication/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/communication/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/communication/EventBase.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/communication/EventBase.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/communication/ExtensionAlpha.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/communication/ExtensionAlpha.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/communication/ExtensionBeta.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/communication/ExtensionBeta.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/communication/ExtensionsCommunicationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/communication/ExtensionsCommunicationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/communication/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/communication/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/communication/PatEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/communication/PatEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/communication/PbEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/communication/PbEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/BasicConfiguratorsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/BasicConfiguratorsTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/DummyConfiguringExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/DummyConfiguringExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/AnimalShelter.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/AnimalShelter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/AnnotatedTypeConfiguratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/AnnotatedTypeConfiguratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/Cat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/Cat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/Cats.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/Cats.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/Countryside.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/Countryside.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/Dog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/Dog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/DogDependenciesProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/DogDependenciesProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/DogProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/DogProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/Dogs.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/Dogs.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/Feed.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/Feed.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/ProcessAnnotatedTypeObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/ProcessAnnotatedTypeObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/Room.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/Room.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/Wild.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/Wild.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/WildAnimalProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/WildAnimalProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/beforeBeanDiscovery/AnnotatedTypeConfiguratorInBBDTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/beforeBeanDiscovery/AnnotatedTypeConfiguratorInBBDTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/beforeBeanDiscovery/BBDObservingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/beforeBeanDiscovery/BBDObservingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/beforeBeanDiscovery/CustomBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/beforeBeanDiscovery/CustomBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/beforeBeanDiscovery/CustomQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/beforeBeanDiscovery/CustomQualifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/beforeBeanDiscovery/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/beforeBeanDiscovery/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/beforeBeanDiscovery/FooInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/annotatedTypeConfigurator/beforeBeanDiscovery/FooInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/BeanConfiguratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/BeanConfiguratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/Bogey.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/Bogey.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/Dangerous.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/Dangerous.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/DesireToHurtHumans.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/DesireToHurtHumans.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/Dungeon.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/Dungeon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/Ghost.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/Ghost.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/LifecycleObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/LifecycleObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/Monster.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/Monster.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/MonsterController.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/MonsterController.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/Skeleton.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/Skeleton.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/Undead.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/Undead.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/Vampire.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/Vampire.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/Weapon.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/Weapon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/Werewolf.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/Werewolf.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/Zombie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/Zombie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/alternativePriority/AlternativePriorityExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/alternativePriority/AlternativePriorityExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/alternativePriority/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/alternativePriority/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/alternativePriority/BeanConfiguratorAlternativePriorityTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/alternativePriority/BeanConfiguratorAlternativePriorityTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/alternativePriority/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/bean/alternativePriority/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/beanAttributes/Axe.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/beanAttributes/Axe.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/beanAttributes/BeanAttributesConfiguratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/beanAttributes/BeanAttributesConfiguratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/beanAttributes/Equipment.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/beanAttributes/Equipment.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/beanAttributes/Hoe.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/beanAttributes/Hoe.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/beanAttributes/Mace.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/beanAttributes/Mace.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/beanAttributes/Melee.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/beanAttributes/Melee.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/beanAttributes/ProcessBeanAttributesObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/beanAttributes/ProcessBeanAttributesObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/beanAttributes/Reforged.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/beanAttributes/Reforged.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/beanAttributes/Sword.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/beanAttributes/Sword.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/beanAttributes/Tool.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/beanAttributes/Tool.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/beanAttributes/TwoHanded.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/beanAttributes/TwoHanded.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/beanAttributes/UsableItem.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/beanAttributes/UsableItem.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/beanAttributes/Weapon.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/beanAttributes/Weapon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/AirPlane.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/AirPlane.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/Car.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/Car.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/CarDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/CarDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/Driving.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/Driving.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/Engine.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/Engine.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/EngineProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/EngineProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/Flying.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/Flying.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/Helicopter.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/Helicopter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/InjectionPointConfiguratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/InjectionPointConfiguratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/ProcessInjectionPointObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/ProcessInjectionPointObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/Ship.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/Ship.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/Tank.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/Tank.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/Vehicle.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionPoint/Vehicle.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionTargetFactory/InjectionTargetFactoryConfigureTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionTargetFactory/InjectionTargetFactoryConfigureTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionTargetFactory/IoCForFramework.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionTargetFactory/IoCForFramework.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionTargetFactory/NotOurClass.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionTargetFactory/NotOurClass.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionTargetFactory/SomeService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionTargetFactory/SomeService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionTargetFactory/SomeServiceImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/injectionTargetFactory/SomeServiceImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/invalid/Box.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/invalid/Box.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/invalid/BoxObserverMethod.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/invalid/BoxObserverMethod.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/invalid/ConfiguratorAndSetMethodTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/invalid/ConfiguratorAndSetMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/invalid/ConfigureAndSetExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/invalid/ConfigureAndSetExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/invalid/Sorted.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/invalid/Sorted.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/invalid/TestAnnotatedType.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/invalid/TestAnnotatedType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/invalid/Warehouse.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/invalid/Warehouse.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/invalid/Worker.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/invalid/Worker.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/AfterBeanDiscoveryObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/AfterBeanDiscoveryObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/Apple.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/Apple.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/Banana.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/Banana.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/Cherry.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/Cherry.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/Delicious.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/Delicious.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/Fruit.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/Fruit.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/FruitObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/FruitObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/Kiwi.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/Kiwi.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/Melon.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/Melon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/ObserverMethodConfiguratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/ObserverMethodConfiguratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/Orange.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/Orange.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/Papaya.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/Papaya.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/Peach.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/Peach.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/Pear.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/Pear.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/Pineapple.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/Pineapple.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/ProcessObserverMethodObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/ProcessObserverMethodObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/ProcessSyntheticObserverMethodObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/ProcessSyntheticObserverMethodObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/Ripe.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/observerMethod/Ripe.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/producer/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/producer/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/producer/MassProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/producer/MassProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/producer/ParameterInjectedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/producer/ParameterInjectedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/producer/ProducerConfiguratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/producer/ProducerConfiguratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/producer/ProducerConfiguringExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/producer/ProducerConfiguringExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/producer/Some.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/producer/Some.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/producer/broken/AddAndConfigureExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/producer/broken/AddAndConfigureExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/producer/broken/AnotherProducerBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/producer/broken/AnotherProducerBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/producer/broken/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/producer/broken/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/producer/broken/ModifyingProducerViaConfigureAndSetTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/producer/broken/ModifyingProducerViaConfigureAndSetTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/producer/broken/ProducerBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/configurators/producer/broken/ProducerBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/container/event/broken/processBeanObserverRegistersException/AddDefinitionErrorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/container/event/broken/processBeanObserverRegistersException/AddDefinitionErrorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/container/event/broken/processBeanObserverRegistersException/ProcessBeanObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/container/event/broken/processBeanObserverRegistersException/ProcessBeanObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/container/event/broken/processBeanObserverRegistersException/Sheep.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/container/event/broken/processBeanObserverRegistersException/Sheep.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/container/event/broken/processBeanObserverThrowsException/ProcessBeanObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/container/event/broken/processBeanObserverThrowsException/ProcessBeanObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/container/event/broken/processBeanObserverThrowsException/Sheep.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/container/event/broken/processBeanObserverThrowsException/Sheep.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/container/event/broken/processBeanObserverThrowsException/ThrowExceptionInProcessBeanObserverTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/container/event/broken/processBeanObserverThrowsException/ThrowExceptionInProcessBeanObserverTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/Custom.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/Custom.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/FinalProduct.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/FinalProduct.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/InterceptionFactoryTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/InterceptionFactoryTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/Product.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/Product.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/ProductInterceptor1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/ProductInterceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/ProductInterceptor2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/ProductInterceptor2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/ProductInterceptor3.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/ProductInterceptor3.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/ProductInterceptorBinding1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/ProductInterceptorBinding1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/ProductInterceptorBinding2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/ProductInterceptorBinding2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/ProductInterceptorBinding3.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/ProductInterceptorBinding3.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/ProductProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/ProductProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/broken/BeanWithInvalidInjectionPoint.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/broken/BeanWithInvalidInjectionPoint.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/broken/BrokenInterceptedInstanceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/broken/BrokenInterceptedInstanceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/broken/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/broken/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/broken/InterceptedInstanceProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/broken/InterceptedInstanceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/broken/InvalidInterceptionFactoryInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/broken/InvalidInterceptionFactoryInjectionPointTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/broken/UnproxyableType.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/broken/UnproxyableType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/customBean/Account.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/customBean/Account.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/customBean/AfterBeanDiscoveryObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/customBean/AfterBeanDiscoveryObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/customBean/Custom.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/customBean/Custom.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/customBean/CustomBeanWithInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/customBean/CustomBeanWithInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/customBean/FeeBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/customBean/FeeBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/customBean/FeeInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptionFactory/customBean/FeeInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/annotation/BooInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/annotation/BooInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/annotation/InterceptorAnnotationExtensionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/annotation/InterceptorAnnotationExtensionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/annotation/InterceptorsExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/annotation/InterceptorsExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/annotation/InterceptorsLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/annotation/InterceptorsLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/annotation/SimpleBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/annotation/SimpleBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/custom/AbstractInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/custom/AbstractInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/custom/CustomInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/custom/CustomInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/custom/CustomInterceptorExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/custom/CustomInterceptorExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/custom/CustomInterceptorInvocationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/custom/CustomInterceptorInvocationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/custom/CustomInterceptorRegistrationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/custom/CustomInterceptorRegistrationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/custom/FooInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/custom/FooInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/custom/FooInterceptorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/custom/FooInterceptorBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/custom/InterceptedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/custom/InterceptedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/custom/InterceptedSerializableBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/interceptors/custom/InterceptedSerializableBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/ExtensionLifecycleTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/ExtensionLifecycleTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/SimpleBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/SimpleBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/SimpleEvent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/SimpleEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/SimpleExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/SimpleExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/SuperExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/SuperExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/AfterTypeDiscoveryObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/AfterTypeDiscoveryObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/AfterTypeDiscoveryTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/AfterTypeDiscoveryTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/AlphaAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/AlphaAlternative.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/AlphaDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/AlphaDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/AlphaInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/AlphaInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/Alternatives.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/Alternatives.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/BravoAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/BravoAlternative.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/BravoDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/BravoDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/BravoInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/BravoInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/CharlieAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/CharlieAlternative.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/CharlieDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/CharlieDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/CharlieInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/CharlieInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/DeltaAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/DeltaAlternative.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/DeltaAlternativeBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/DeltaAlternativeBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/DeltaDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/DeltaDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/DeltaDecoratorBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/DeltaDecoratorBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/DeltaInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/DeltaInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/DeltaInterceptorBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/DeltaInterceptorBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/EchoAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/EchoAlternative.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2018, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/EchoDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/EchoDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2018, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/EchoInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/EchoInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2018, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/Logger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/Logger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/Monitored.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/Monitored.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/TransactionLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/TransactionLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/broken/ThrowExceptionExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/broken/ThrowExceptionExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/broken/ThrowExceptionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/broken/ThrowExceptionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/lib/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/lib/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/lib/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/lib/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/lib/Boss.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/lib/Boss.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/lib/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/lib/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/lib/Pro.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/lib/Pro.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/massOperations/AfterTypeBeanDiscoveryMassOperationObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/massOperations/AfterTypeBeanDiscoveryMassOperationObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2018, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/massOperations/AfterTypeDiscoveryMassOperationsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/massOperations/AfterTypeDiscoveryMassOperationsTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2018, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/massOperations/AlphaAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/massOperations/AlphaAlternative.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2018, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/massOperations/AlphaDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/massOperations/AlphaDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2018, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/massOperations/AlphaInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/massOperations/AlphaInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2018, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/massOperations/BetaAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/massOperations/BetaAlternative.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2018, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/massOperations/BetaDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/massOperations/BetaDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2018, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/massOperations/BetaInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/massOperations/BetaInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2018, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/massOperations/GammaAlternative.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/massOperations/GammaAlternative.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2018, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/massOperations/GammaDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/massOperations/GammaDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2018, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/massOperations/GammaInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/atd/massOperations/GammaInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2018, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/Alligator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/Alligator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/BeforeBeanDiscoveryObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/BeforeBeanDiscoveryObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/BeforeBeanDiscoveryTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/BeforeBeanDiscoveryTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/DataAccess.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/DataAccess.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/DataAccessAuthorizationDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/DataAccessAuthorizationDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/DataAccessImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/DataAccessImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/DeploymentTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/DeploymentTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/DisabledBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/DisabledBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/EpochScoped.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/EpochScoped.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/Interceptor1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/Interceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/InterceptorType1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/InterceptorType1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/ManagerObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/ManagerObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/NotAuthorizedException.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/NotAuthorizedException.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/Programmer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/Programmer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/RomanEmpire.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/RomanEmpire.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/Skill.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/Skill.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/SkillLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/SkillLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/User.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/User.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/broken/exception/BeforeBeanDiscoveryObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/broken/exception/BeforeBeanDiscoveryObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/broken/exception/BeforeBeanDiscoveryThrowsExceptionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/broken/exception/BeforeBeanDiscoveryThrowsExceptionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/broken/normalScope/AddingNormalScopeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/broken/normalScope/AddingNormalScopeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/broken/normalScope/BeforeBeanDiscoveryObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/broken/normalScope/BeforeBeanDiscoveryObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/broken/normalScope/Caesar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/broken/normalScope/Caesar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/broken/normalScope/EpochScoped.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/broken/normalScope/EpochScoped.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/broken/normalScope/RomanEmpire.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/broken/normalScope/RomanEmpire.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/broken/passivatingScope/AddingPassivatingScopeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/broken/passivatingScope/AddingPassivatingScopeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/broken/passivatingScope/BeforeBeanDiscoveryObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/broken/passivatingScope/BeforeBeanDiscoveryObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/broken/passivatingScope/EpochScoped.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/broken/passivatingScope/EpochScoped.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/broken/passivatingScope/RomanEmpire.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/broken/passivatingScope/RomanEmpire.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/lib/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/lib/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/lib/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/lib/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/lib/Boss.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/lib/Boss.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/lib/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/lib/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/lib/Pro.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/lib/Pro.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/addDefinitionError/AddDefinitionErrorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/addDefinitionError/AddDefinitionErrorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/addDefinitionError/AfterBeanDiscoveryObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/addDefinitionError/AfterBeanDiscoveryObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/addDeploymentProblem/AddDeploymentProblemTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/addDeploymentProblem/AddDeploymentProblemTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/addDeploymentProblem/AfterDeploymentValidationObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/addDeploymentProblem/AfterDeploymentValidationObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/exception/discovery/AfterBeanDiscoveryObserverExecutionFailureTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/exception/discovery/AfterBeanDiscoveryObserverExecutionFailureTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/exception/discovery/BeanDiscoveryObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/exception/discovery/BeanDiscoveryObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/exception/discovery/FooException.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/exception/discovery/FooException.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/exception/validation/AfterDeploymentValidationObserverExecutionFailureTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/exception/validation/AfterDeploymentValidationObserverExecutionFailureTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/exception/validation/ValidationObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/exception/validation/ValidationObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/observerMethod/AfterBeanDiscoveryObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/observerMethod/AfterBeanDiscoveryObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/observerMethod/CustomObserverMethodWithoutNotifyMethodTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/observerMethod/CustomObserverMethodWithoutNotifyMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/observerMethod/ExtensionAddingCustomObserverMethod.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/observerMethod/ExtensionAddingCustomObserverMethod.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/observerMethod/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/observerMethod/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/observerMethod/FooObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/observerMethod/FooObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/observerMethod/ObserverMethodWithoutNotifyMethodTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/broken/observerMethod/ObserverMethodWithoutNotifyMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/Alpha.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/Alpha.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/AlphaQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/AlphaQualifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/AlphaStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/AlphaStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/Bravo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/Bravo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/BravoDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/BravoDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/BravoInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/BravoInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/BravoInterceptorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/BravoInterceptorBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/BravoInterface.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/BravoInterface.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/BravoProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/BravoProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/BravoQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/BravoQualifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/Charlie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/Charlie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/CharlieInterface.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/CharlieInterface.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/CharlieProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/CharlieProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/CharlieQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/CharlieQualifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/Mike.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/Mike.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/VerifyValuesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/VerifyValuesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/VerifyingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/VerifyingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/AddDefinitionErrorExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/AddDefinitionErrorExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/AddDefinitionErrorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/AddDefinitionErrorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/BrokenException.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/BrokenException.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/Duke.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/Duke.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/ThrowExceptionExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/ThrowExceptionExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/ThrowExceptionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/ThrowExceptionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/invalid/InvalidQualifierExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/invalid/InvalidQualifierExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/invalid/InvalidQualifierTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/invalid/InvalidQualifierTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/invalid/InvalidScopeExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/invalid/InvalidScopeExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/invalid/InvalidScopeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/invalid/InvalidScopeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/invalid/InvalidStereotypeExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/invalid/InvalidStereotypeExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/invalid/InvalidStereotypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/invalid/InvalidStereotypeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/invalid/InvalidTypesExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/invalid/InvalidTypesExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/invalid/InvalidTypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/invalid/InvalidTypesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/invalid/PlainOldAnnotation.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/invalid/PlainOldAnnotation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/invalid/Telephone.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/invalid/Telephone.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/passivation/Bicycle.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/passivation/Bicycle.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/passivation/Laptop.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/passivation/Laptop.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/passivation/ModifyingExtension1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/passivation/ModifyingExtension1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/passivation/ModifyingExtension2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/passivation/ModifyingExtension2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/passivation/PassivationCapabilityErrorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/passivation/PassivationCapabilityErrorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/passivation/PassivationCapableDependencyErrorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/passivation/PassivationCapableDependencyErrorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/passivation/Wheel.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/broken/passivation/Wheel.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/decorator/Alpha.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/decorator/Alpha.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/decorator/AlphaDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/decorator/AlphaDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/decorator/Bravo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/decorator/Bravo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/decorator/BravoDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/decorator/BravoDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/decorator/Charlie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/decorator/Charlie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/decorator/DecoratorProcessBeanAttributesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/decorator/DecoratorProcessBeanAttributesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/decorator/VerifyingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/decorator/VerifyingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/ignoreFinalMethods/IgnoreFinalMethodsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/ignoreFinalMethods/IgnoreFinalMethodsTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/ignoreFinalMethods/IgnoringExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/ignoreFinalMethods/IgnoringExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/ignoreFinalMethods/Qux.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/ignoreFinalMethods/Qux.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/interceptor/AlphaInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/interceptor/AlphaInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/interceptor/AlphaInterceptorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/interceptor/AlphaInterceptorBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/interceptor/BravoInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/interceptor/BravoInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/interceptor/BravoInterceptorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/interceptor/BravoInterceptorBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/interceptor/InterceptorProcessBeanAttributesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/interceptor/InterceptorProcessBeanAttributesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/interceptor/VerifyingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/interceptor/VerifyingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/modify/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/modify/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/modify/Cat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/modify/Cat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/modify/Cute.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/modify/Cute.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/modify/ModifyingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/modify/ModifyingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/modify/PersianStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/modify/PersianStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/modify/SetBeanAttributesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/modify/SetBeanAttributesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/modify/Wild.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/modify/Wild.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/modify/broken/ModifyingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/modify/broken/ModifyingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/modify/broken/Mouse.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/modify/broken/Mouse.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/modify/broken/SetBeanAttributesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/modify/broken/SetBeanAttributesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/Alpha.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/Alpha.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/Bravo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/Bravo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/Charlie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/Charlie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/SpecializationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/SpecializationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/VerifyingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/VerifyingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/VetoTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/VetoTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/VetoingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/VetoingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/broken/Specialized.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/broken/Specialized.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/broken/Specializing.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/broken/Specializing.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/broken/TypeConflictDetectionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/broken/TypeConflictDetectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/broken/TypeExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/specialization/broken/TypeExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/synthetic/Bicycle.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/synthetic/Bicycle.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/synthetic/BicycleBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/synthetic/BicycleBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/synthetic/BicycleExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/synthetic/BicycleExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/synthetic/ProcessBeanAttributesNotFiredForSyntheticBeanTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/synthetic/ProcessBeanAttributesNotFiredForSyntheticBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/synthetic/Vehicle.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/synthetic/Vehicle.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/veto/Car.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/veto/Car.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/veto/Factory.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/veto/Factory.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/veto/Field.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/veto/Field.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/veto/Flower.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/veto/Flower.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/veto/VetoTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/veto/VetoTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/veto/VetoingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/veto/VetoingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/veto/Wheat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processBeanAttributes/veto/Wheat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/Alpha.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/Alpha.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/Bravo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/Bravo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/BravoObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/BravoObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/Charlie.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/Charlie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/Delta.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/Delta.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/InjectingBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/InjectingBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/PlainAnnotation.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/PlainAnnotation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/ProcessInjectionPointFiredTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/ProcessInjectionPointFiredTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/ProducedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/ProducedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/VerifyingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/VerifyingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/broken/AddDefinitionErrorExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/broken/AddDefinitionErrorExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/broken/AddDefinitionErrorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/broken/AddDefinitionErrorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/broken/BrokenException.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/broken/BrokenException.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/broken/Duke.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/broken/Duke.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/broken/ThrowExceptionExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/broken/ThrowExceptionExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/broken/ThrowExceptionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/broken/ThrowExceptionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/broken/World.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/broken/World.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/modify/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/modify/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/modify/AnimalDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/modify/AnimalDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/modify/Dog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/modify/Dog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/modify/Fast.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/modify/Fast.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/modify/Hound.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/modify/Hound.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/modify/InjectingBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/modify/InjectingBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/modify/InjectionPointOverridingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/modify/InjectionPointOverridingTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/modify/Lazy.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/modify/Lazy.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/modify/ModifyingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/processInjectionPoint/modify/ModifyingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lite/coexistence/BuildCompatibleExtensionSmokeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lite/coexistence/BuildCompatibleExtensionSmokeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2022, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lite/coexistence/DummyBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lite/coexistence/DummyBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2022, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lite/coexistence/OverridenBuildCompatibleExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lite/coexistence/OverridenBuildCompatibleExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2022, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lite/coexistence/OverridingPortableExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lite/coexistence/OverridingPortableExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2022, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lite/coexistence/StandardBuildCompatibleExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lite/coexistence/StandardBuildCompatibleExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2022, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lite/coexistence/StandardPortableExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lite/coexistence/StandardPortableExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2022, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/EventA.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/EventA.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/EventB.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/EventB.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/EventBObserverMethod.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/EventBObserverMethod.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/EventC.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/EventC.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/EventD.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/EventD.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/EventObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/EventObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/ProcessObserverMethodEventTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/ProcessObserverMethodEventTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/ProcessObserverMethodObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/ProcessObserverMethodObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/broken/definitionError/EventB.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/broken/definitionError/EventB.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/broken/definitionError/EventBObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/broken/definitionError/EventBObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/broken/definitionError/ProcessObserverMethodErrorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/broken/definitionError/ProcessObserverMethodErrorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/broken/definitionError/ProcessObserverMethodObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/broken/definitionError/ProcessObserverMethodObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/broken/exception/EventC.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/broken/exception/EventC.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/broken/exception/EventCObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/broken/exception/EventCObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/broken/exception/ProcessObserverMethodExceptionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/broken/exception/ProcessObserverMethodExceptionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/broken/exception/ProcessObserverMethodObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/broken/exception/ProcessObserverMethodObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/priority/ExtensionObserverOrderingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/priority/ExtensionObserverOrderingTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015 Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/priority/TestBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/priority/TestBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015 Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/priority/TestExtension01.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/priority/TestExtension01.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015 Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/priority/TestExtension02.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/priority/TestExtension02.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015 Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/priority/TestExtension03.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/observer/priority/TestExtension03.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015 Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/processBean/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/processBean/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/processBean/AnimalDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/processBean/AnimalDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/processBean/Cat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/processBean/Cat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/processBean/CatInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/processBean/CatInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/processBean/CatInterceptorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/processBean/CatInterceptorBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/processBean/Chicken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/processBean/Chicken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/processBean/ChickenHutch.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/processBean/ChickenHutch.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/processBean/Cow.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/processBean/Cow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/processBean/Cowshed.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/processBean/Cowshed.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/processBean/Domestic.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/processBean/Domestic.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/processBean/ProcessBeanObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/processBean/ProcessBeanObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/processBean/ProcessBeanTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/processBean/ProcessBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/Bird.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/Bird.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/BirdCage.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/BirdCage.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/CanSpeakDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/CanSpeakDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/Cat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/Cat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/CatFoodDish.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/CatFoodDish.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/CatHolder.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/CatHolder.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/CatHolderInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/CatHolderInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/CatInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/CatInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/CatSpectator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/CatSpectator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/CheckableInjectionTarget.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/CheckableInjectionTarget.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/Cow.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/Cow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/CowProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/CowProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/Dog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/Dog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/DogBed.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/DogBed.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/DogBone.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/DogBone.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/DogProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/DogProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/LitterBox.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/LitterBox.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/Noisy.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/Noisy.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/Preferred.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/Preferred.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/ProducerProcessor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/ProducerProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/ProducerTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/ProducerTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/Quiet.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/Quiet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/Speakable.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/Speakable.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/Tabby.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/Tabby.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/broken/injectionTargetError/Dog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/broken/injectionTargetError/Dog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/broken/injectionTargetError/EventProcessor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/broken/injectionTargetError/EventProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/broken/injectionTargetError/InjectionTargetDefinitionErrorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/broken/injectionTargetError/InjectionTargetDefinitionErrorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/broken/processing/ExplicitDefinitionErrorExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/broken/processing/ExplicitDefinitionErrorExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/broken/processing/ExplicitExceptionExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/broken/processing/ExplicitExceptionExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/broken/processing/Gold.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/broken/processing/Gold.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/broken/processing/GoldProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/broken/processing/GoldProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/broken/processing/ProducerProcessingWithDefinitionErrorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/broken/processing/ProducerProcessingWithDefinitionErrorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/broken/processing/ProducerProcessingWithExceptionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/producer/broken/processing/ProducerProcessingWithExceptionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/stereotype/Chair.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/stereotype/Chair.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/stereotype/StereotypeCandidate.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/stereotype/StereotypeCandidate.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/stereotype/StereotypeExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/stereotype/StereotypeExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/stereotype/StereotypeExtensionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/stereotype/StereotypeExtensionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/BuiltinMetadataBeanTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/BuiltinMetadataBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/Frozen.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/Frozen.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/Fruit.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/Fruit.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/MilkProduct.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/MilkProduct.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/MilkProductDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/MilkProductDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/Probiotic.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/Probiotic.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/Yoghurt.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/Yoghurt.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/YoghurtFactory.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/YoghurtFactory.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/YoghurtInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/YoghurtInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/injection/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/injection/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/injection/BuiltinDecoratorInjectionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/injection/BuiltinDecoratorInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/injection/decorated/DecoratedBeanConstructorInjectionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/injection/decorated/DecoratedBeanConstructorInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/injection/decorated/DecoratedBeanFieldInjectionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/injection/decorated/DecoratedBeanFieldInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/injection/decorated/DecoratedBeanInitializerInjectionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/injection/decorated/DecoratedBeanInitializerInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/injection/decorated/DecoratedConstructorInjector.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/injection/decorated/DecoratedConstructorInjector.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/injection/decorated/DecoratedFieldInjector.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/injection/decorated/DecoratedFieldInjector.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/injection/decorated/DecoratedInitializerInjector.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/injection/decorated/DecoratedInitializerInjector.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/typeparam/decorator/DecoratorTypeParamConstructorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/typeparam/decorator/DecoratorTypeParamConstructorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/typeparam/decorator/DecoratorTypeParamFieldTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/typeparam/decorator/DecoratorTypeParamFieldTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/typeparam/decorator/DecoratorTypeParamInitializerTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/typeparam/decorator/DecoratorTypeParamInitializerTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/typeparam/decorator/DecoratoredBeanTypeParamConstructorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/typeparam/decorator/DecoratoredBeanTypeParamConstructorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/typeparam/decorator/DecoratoredBeanTypeParamFieldTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/typeparam/decorator/DecoratoredBeanTypeParamFieldTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/typeparam/decorator/DecoratoredBeanTypeParamInitializerTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/typeparam/decorator/DecoratoredBeanTypeParamInitializerTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/typeparam/decorator/MilkDecoratedBeanConstructor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/typeparam/decorator/MilkDecoratedBeanConstructor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/typeparam/decorator/MilkDecoratedBeanField.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/typeparam/decorator/MilkDecoratedBeanField.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/typeparam/decorator/MilkDecoratedBeanInitializer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/typeparam/decorator/MilkDecoratedBeanInitializer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/typeparam/decorator/MilkDecoratorConstructor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/typeparam/decorator/MilkDecoratorConstructor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/typeparam/decorator/MilkDecoratorField.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/typeparam/decorator/MilkDecoratorField.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/typeparam/decorator/MilkDecoratorInitializer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/builtin/metadata/broken/typeparam/decorator/MilkDecoratorInitializer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/disposal/method/definition/broken/decorator/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/disposal/method/definition/broken/decorator/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/disposal/method/definition/broken/decorator/DisposerMethodOnDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/disposal/method/definition/broken/decorator/DisposerMethodOnDecoratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/disposal/method/definition/broken/decorator/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/disposal/method/definition/broken/decorator/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/disposal/method/definition/broken/decorator/FooDecorator_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/disposal/method/definition/broken/decorator/FooDecorator_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/disposal/method/definition/broken/decorator/Number.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/disposal/method/definition/broken/decorator/Number.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/definition/broken/decorator/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/definition/broken/decorator/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/definition/broken/decorator/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/definition/broken/decorator/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/definition/broken/decorator/FooDecorator_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/definition/broken/decorator/FooDecorator_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/definition/broken/decorator/Number.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/definition/broken/decorator/Number.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/definition/broken/decorator/ProducerFieldOnDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/definition/broken/decorator/ProducerFieldOnDecoratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/DeadlyAnimal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/DeadlyAnimal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/DeadlySpider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/DeadlySpider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/DefangedTarantula.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/DefangedTarantula.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/ProducerFieldLifecycleTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/ProducerFieldLifecycleTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/SpecializedTarantulaProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/SpecializedTarantulaProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/Spider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/Spider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/Tarantula.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/Tarantula.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/TarantulaConsumer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/TarantulaConsumer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/TarantulaProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/field/lifecycle/TarantulaProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/broken/decorator/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/broken/decorator/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/broken/decorator/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/broken/decorator/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/broken/decorator/FooDecorator_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/broken/decorator/FooDecorator_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/broken/decorator/Number.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/broken/decorator/Number.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/broken/decorator/ProducerMethodOnDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/broken/decorator/ProducerMethodOnDecoratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/definition/AndalusianChicken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/definition/AndalusianChicken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/definition/Chicken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/definition/Chicken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/definition/Egg.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/definition/Egg.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/definition/ProducerMethodDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/definition/ProducerMethodDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/definition/Yummy.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/definition/Yummy.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/DeadlyAnimal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/DeadlyAnimal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/DeadlySpider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/DeadlySpider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/Null.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/Null.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/Pet.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/Pet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/PreferredSpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/PreferredSpiderProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/ProducerMethodLifecycleTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/ProducerMethodLifecycleTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/Spider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/Spider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/SpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/SpiderProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/Tarantula.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/Tarantula.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/Web.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/producer/method/lifecycle/Web.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/simple/lifecycle/Bream.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/simple/lifecycle/Bream.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/simple/lifecycle/Cod.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/simple/lifecycle/Cod.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/simple/lifecycle/Lion.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/simple/lifecycle/Lion.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/simple/lifecycle/MountainLion.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/simple/lifecycle/MountainLion.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/simple/lifecycle/SimpleBeanLifecycleTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/simple/lifecycle/SimpleBeanLifecycleTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/simple/lifecycle/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/implementation/simple/lifecycle/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/Expensive.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/Expensive.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/JewelryShop.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/JewelryShop.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/Necklace.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/Necklace.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/ProducerMethodSpecializationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/ProducerMethodSpecializationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/Product.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/Product.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/Shop.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/Shop.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/Sparkly.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/Sparkly.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/indirectoverride/Expensive.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/indirectoverride/Expensive.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/indirectoverride/IndirectOverrideTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/indirectoverride/IndirectOverrideTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/indirectoverride/MallShop.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/indirectoverride/MallShop.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/indirectoverride/Product.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/indirectoverride/Product.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/indirectoverride/ShoeShop_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/indirectoverride/ShoeShop_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/indirectoverride/Shop.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/indirectoverride/Shop.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/name/HighSchool_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/name/HighSchool_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/name/Pupil.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/name/Pupil.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/name/School.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/name/School.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/name/SpecializingAndSpecializedBeanHaveNameTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/name/SpecializingAndSpecializedBeanHaveNameTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/staticmethod/Expensive.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/staticmethod/Expensive.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/staticmethod/FurnitureShop_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/staticmethod/FurnitureShop_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/staticmethod/Product.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/staticmethod/Product.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/staticmethod/Shop.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/staticmethod/Shop.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/staticmethod/SpecializesStaticMethodTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/staticmethod/SpecializesStaticMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/twobeans/Bookshop_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/twobeans/Bookshop_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/twobeans/Expensive.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/twobeans/Expensive.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/twobeans/PictureShop_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/twobeans/PictureShop_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/twobeans/Product.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/twobeans/Product.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/twobeans/Shop.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/twobeans/Shop.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/twobeans/TwoBeansSpecializeTheSameBeanTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/producer/method/broken/twobeans/TwoBeansSpecializeTheSameBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/qualifiers/DataProvider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/qualifiers/DataProvider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/qualifiers/DataProviderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/qualifiers/DataProviderProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/qualifiers/Mock.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/qualifiers/Mock.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/qualifiers/MockDataProviderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/qualifiers/MockDataProviderProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/qualifiers/MockSpecializationBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/qualifiers/MockSpecializationBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/qualifiers/SpecializationBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/qualifiers/SpecializationBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/qualifiers/SpecializingBeanQualifiersTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/qualifiers/SpecializingBeanQualifiersTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/qualifiers/StaticNestedClassesParent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/qualifiers/StaticNestedClassesParent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/Building.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/Building.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/Egg.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/Egg.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/Farmer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/Farmer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/Human.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/Human.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/Landowner.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/Landowner.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/Lazy.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/Lazy.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/LazyFarmer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/LazyFarmer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/Office.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/Office.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/SimpleBeanSpecializationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/SimpleBeanSpecializationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/Waste.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/Waste.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/inconsistent/Employee.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/inconsistent/Employee.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/inconsistent/InconsistentSpecializationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/inconsistent/InconsistentSpecializationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/inconsistent/Maid.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/inconsistent/Maid.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/inconsistent/Manager.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/inconsistent/Manager.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/names/FarmYard_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/names/FarmYard_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/names/SpecializingAndSpecializedBeanHasNameTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/names/SpecializingAndSpecializedBeanHasNameTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/names/Yard.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/names/Yard.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/noextend1/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/noextend1/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/noextend1/Donkey_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/noextend1/Donkey_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/noextend1/SpecializingBeanImplementsInterfaceOnlyTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/noextend1/SpecializingBeanImplementsInterfaceOnlyTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/noextend2/Cow_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/noextend2/Cow_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/noextend2/SpecializingBeanExtendsNothingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/noextend2/SpecializingBeanExtendsNothingTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/noextend3/Cow_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/noextend3/Cow_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/noextend3/Mammal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/noextend3/Mammal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/noextend3/SpecializingClassExtendsNonSimpleBeanTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/noextend3/SpecializingClassExtendsNonSimpleBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/types/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/types/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/types/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/types/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/types/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/types/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/types/SpecializingBeanWithoutBeanTypeOfSpecializedBeanTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/inheritance/specialization/simple/broken/types/SpecializingBeanWithoutBeanTypeOfSpecializedBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/Dog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/Dog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/DogInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/DogInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/Fish.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/Fish.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/FishInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/FishInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/InterceptorBindingsWithAtInterceptorsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/InterceptorBindingsWithAtInterceptorsTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/InterceptorBindingsWithInterceptorFactoryTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/InterceptorBindingsWithInterceptorFactoryTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2024, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProducerBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProducerBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2024, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/Product.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/Product.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2024, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptor1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2024, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptor2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptor2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2024, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptorBinding1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptorBinding1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2024, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptorBinding2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptorBinding2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2024, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptorBinding3.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/invocationContext/ProductInterceptorBinding3.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2024, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/lifecycleCallback/wrapped/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/lifecycleCallback/wrapped/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/lifecycleCallback/wrapped/Bird.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/lifecycleCallback/wrapped/Bird.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/lifecycleCallback/wrapped/Eagle.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/lifecycleCallback/wrapped/Eagle.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/lifecycleCallback/wrapped/LifecycleCallbackInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/lifecycleCallback/wrapped/LifecycleCallbackInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/lifecycleCallback/wrapped/WrappingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/contract/lifecycleCallback/wrapped/WrappingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/broken/interceptorCanNotBeDecorator/Automobile.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/broken/interceptorCanNotBeDecorator/Automobile.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/broken/interceptorCanNotBeDecorator/InterceptingDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/broken/interceptorCanNotBeDecorator/InterceptingDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/broken/interceptorCanNotBeDecorator/InterceptorCanNotBeDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/broken/interceptorCanNotBeDecorator/InterceptorCanNotBeDecoratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/broken/nonExistantClassInBeansXml/DummyBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/broken/nonExistantClassInBeansXml/DummyBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/broken/nonExistantClassInBeansXml/NonExistantClassInBeansXmlTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/broken/nonExistantClassInBeansXml/NonExistantClassInBeansXmlTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/broken/nonInterceptorClassInBeansXml/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/broken/nonInterceptorClassInBeansXml/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/broken/nonInterceptorClassInBeansXml/NonInterceptorClassInBeansXmlTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/broken/nonInterceptorClassInBeansXml/NonInterceptorClassInBeansXmlTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/broken/sameClassListedTwiceInBeansXml/FordInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/broken/sameClassListedTwiceInBeansXml/FordInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/broken/sameClassListedTwiceInBeansXml/SameClassListedTwiceInBeansXmlTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/broken/sameClassListedTwiceInBeansXml/SameClassListedTwiceInBeansXmlTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/broken/sameClassListedTwiceInBeansXml/Transactional.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/broken/sameClassListedTwiceInBeansXml/Transactional.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/conflictingenablement/AnotherTestDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/conflictingenablement/AnotherTestDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/conflictingenablement/InterceptorConflictingEnablementTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/conflictingenablement/InterceptorConflictingEnablementTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2016, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/conflictingenablement/Logged.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/conflictingenablement/Logged.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/conflictingenablement/LoggingInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/conflictingenablement/LoggingInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/conflictingenablement/Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/conflictingenablement/Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/conflictingenablement/TestBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/conflictingenablement/TestBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/conflictingenablement/TestDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/conflictingenablement/TestDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/conflictingenablement/Transactional.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/conflictingenablement/Transactional.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/conflictingenablement/TransactionalInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/conflictingenablement/TransactionalInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/custom/AfterBeanDiscoveryObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/custom/AfterBeanDiscoveryObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/custom/CustomInterceptorImplementation.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/custom/CustomInterceptorImplementation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/custom/CustomInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/custom/CustomInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/custom/Secure.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/custom/Secure.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/custom/SecureLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/custom/SecureLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/custom/SimpleInterceptorWithoutAnnotations.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/custom/SimpleInterceptorWithoutAnnotations.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/custom/Transactional.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/custom/Transactional.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/custom/TransactionalLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/custom/TransactionalLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorCalledBeforeDecorator/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorCalledBeforeDecorator/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorCalledBeforeDecorator/FooDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorCalledBeforeDecorator/FooDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorCalledBeforeDecorator/FooImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorCalledBeforeDecorator/FooImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorCalledBeforeDecorator/InterceptorCalledBeforeDecoratorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorCalledBeforeDecorator/InterceptorCalledBeforeDecoratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorCalledBeforeDecorator/TransactionInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorCalledBeforeDecorator/TransactionInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorNotListedInBeansXml/AccountHolder.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorNotListedInBeansXml/AccountHolder.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorNotListedInBeansXml/InterceptorNotListedInBeansXmlNotEnabledTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorNotListedInBeansXml/InterceptorNotListedInBeansXmlNotEnabledTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorNotListedInBeansXml/TransactionInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorNotListedInBeansXml/TransactionInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorNotListedInBeansXml/Transactional.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorNotListedInBeansXml/Transactional.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorOrder/AccountBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorOrder/AccountBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorOrder/AccountTransaction.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorOrder/AccountTransaction.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorOrder/AnotherInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorOrder/AnotherInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorOrder/FirstInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorOrder/FirstInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorOrder/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorOrder/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorOrder/InterceptorOrderTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorOrder/InterceptorOrderTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorOrder/SecondInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorOrder/SecondInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorOrder/Secure.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorOrder/Secure.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorOrder/Transaction.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorOrder/Transaction.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorOrder/Transactional.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorOrder/Transactional.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorOrder/TransactionalInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/interceptorOrder/TransactionalInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/lifecycle/order/AccountTransaction.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/lifecycle/order/AccountTransaction.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/lifecycle/order/AnotherInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/lifecycle/order/AnotherInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/lifecycle/order/LifecycleInterceptorOrderTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/lifecycle/order/LifecycleInterceptorOrderTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/lifecycle/order/Transaction.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/lifecycle/order/Transaction.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/lifecycle/order/Transactional.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/lifecycle/order/Transactional.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/lifecycle/order/TransactionalInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/definition/lifecycle/order/TransactionalInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/order/overriden/lifecycleCallback/wrapped/Bird.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/order/overriden/lifecycleCallback/wrapped/Bird.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/order/overriden/lifecycleCallback/wrapped/Eagle.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/order/overriden/lifecycleCallback/wrapped/Eagle.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/order/overriden/lifecycleCallback/wrapped/Falcon.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/order/overriden/lifecycleCallback/wrapped/Falcon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/order/overriden/lifecycleCallback/wrapped/OverridenLifecycleCallbackInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/order/overriden/lifecycleCallback/wrapped/OverridenLifecycleCallbackInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/order/overriden/lifecycleCallback/wrapped/WrappingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/order/overriden/lifecycleCallback/wrapped/WrappingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/tests/contract/method/Dog.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/tests/contract/method/Dog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/tests/contract/method/DogInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/tests/contract/method/DogInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/tests/contract/method/Fish.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/tests/contract/method/Fish.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/tests/contract/method/FishInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/tests/contract/method/FishInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/tests/contract/method/MethodLevelInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/interceptors/tests/contract/method/MethodLevelInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/byname/AlaskaPlaice.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/byname/AlaskaPlaice.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/byname/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/byname/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/byname/Cod.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/byname/Cod.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/byname/Plaice.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/byname/Plaice.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/byname/ResolutionByNameTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/byname/ResolutionByNameTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/byname/Salmon.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/byname/Salmon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/byname/Sole.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/byname/Sole.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/byname/Whitefish.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/byname/Whitefish.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/broken/raw/AfterBeanDiscoveryObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/broken/raw/AfterBeanDiscoveryObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/broken/raw/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/broken/raw/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/broken/raw/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/broken/raw/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/broken/raw/CustomBarBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/broken/raw/CustomBarBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/broken/raw/CustomInstanceInjectionPoint.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/broken/raw/CustomInstanceInjectionPoint.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/broken/raw/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/broken/raw/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/broken/raw/ProcessInjectionPointObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/broken/raw/ProcessInjectionPointObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/broken/raw/RawInstanceCustomBeanTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/broken/raw/RawInstanceCustomBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/broken/raw/RawInstanceProcessInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/broken/raw/RawInstanceProcessInjectionPointTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/destroy/normal/AbstractComponent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/destroy/normal/AbstractComponent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/destroy/normal/AbstractContext.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/destroy/normal/AbstractContext.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/destroy/normal/AlterableComponent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/destroy/normal/AlterableComponent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/destroy/normal/AlterableScoped.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/destroy/normal/AlterableScoped.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/destroy/normal/CustomAlterableContext.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/destroy/normal/CustomAlterableContext.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/destroy/normal/CustomNonAlterableContext.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/destroy/normal/CustomNonAlterableContext.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/destroy/normal/CustomScopeExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/destroy/normal/CustomScopeExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/destroy/normal/DestroyingNormalScopedInstanceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/destroy/normal/DestroyingNormalScopedInstanceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/destroy/normal/NonAlterableComponent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/destroy/normal/NonAlterableComponent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/destroy/normal/NonAlterableScoped.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/dynamic/destroy/normal/NonAlterableScoped.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/el/Counter.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/el/Counter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/el/Game.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/el/Game.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/el/GoldenFish.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/el/GoldenFish.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/el/ResolutionByNameTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/el/ResolutionByNameTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/el/Salmon.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/el/Salmon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/el/Tuna.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/el/Tuna.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/el/TunaFarm.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/el/TunaFarm.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injection/visibility/AbstractBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injection/visibility/AbstractBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injection/visibility/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injection/visibility/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injection/visibility/InjectionVisibilityTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injection/visibility/InjectionVisibilityTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injection/visibility/SimpleSessionBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injection/visibility/SimpleSessionBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/AnimalDecorator1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/AnimalDecorator1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/AnimalDecorator2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/AnimalDecorator2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/AnimalDecorator3.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/AnimalDecorator3.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/AnimalStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/AnimalStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/BasicLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/BasicLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/BeanWithInjectionPointMetadata.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/BeanWithInjectionPointMetadata.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/Cat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/Cat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/Cattery.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/Cattery.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/ConstructorInjectionPointBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/ConstructorInjectionPointBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/FieldInjectionPointBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/FieldInjectionPointBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/InjectableReferenceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/InjectableReferenceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/InjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/InjectionPointTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/Logger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/Logger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/LoggerConsumer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/LoggerConsumer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/MethodInjectionPointBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/MethodInjectionPointBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/TimestampLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/TimestampLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/Toy.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/Toy.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/ambiguous/AmbiguousInjectableReferenceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/ambiguous/AmbiguousInjectableReferenceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/ambiguous/AmbiguousInjectionPoint.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/ambiguous/AmbiguousInjectionPoint.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/ambiguous/AnnotatedInjectionField.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/ambiguous/AnnotatedInjectionField.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/ambiguous/DerivedInjectedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/ambiguous/DerivedInjectedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/ambiguous/InjectedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/ambiguous/InjectedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/ambiguous/SimpleBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/ambiguous/SimpleBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/unresolved/AnnotatedInjectionField.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/unresolved/AnnotatedInjectionField.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/unresolved/InjectedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/unresolved/InjectedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/unresolved/SimpleBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/unresolved/SimpleBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/unresolved/UnsatisfiedInjectableReferenceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/unresolved/UnsatisfiedInjectableReferenceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/unresolved/UnsatisfiedInjectionPoint.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/injectionpoint/broken/reference/unresolved/UnsatisfiedInjectionPoint.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/typesafe/resolution/decorator/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/typesafe/resolution/decorator/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/typesafe/resolution/decorator/AnimalDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/typesafe/resolution/decorator/AnimalDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/typesafe/resolution/decorator/Cat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/typesafe/resolution/decorator/Cat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/typesafe/resolution/decorator/DecoratorNotInjectedTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/typesafe/resolution/decorator/DecoratorNotInjectedTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/typesafe/resolution/decorator/House.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/lookup/typesafe/resolution/decorator/House.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/AnimalStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/AnimalStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/Elephant.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/Elephant.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/Gecko.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/Gecko.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/ModifyingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/ModifyingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/Predator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/Predator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/Reptile.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/Reptile.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/Shark.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/Shark.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/Tiger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/Tiger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/VerifyingExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/VerifyingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/VetoedTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/VetoedTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/aquarium/Fish.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/aquarium/Fish.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/aquarium/FishType.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/aquarium/FishType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/aquarium/Fishy.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/aquarium/Fishy.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/aquarium/Piranha.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/aquarium/Piranha.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/aquarium/package-info.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/full/vetoed/aquarium/package-info.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat Middleware LLC, and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/injection/BuiltinInterceptorInjectionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/injection/BuiltinInterceptorInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/injection/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/injection/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/injection/intercepted/InterceptedBeanConstructorInjectionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/injection/intercepted/InterceptedBeanConstructorInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/injection/intercepted/InterceptedBeanFieldInjectionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/injection/intercepted/InterceptedBeanFieldInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/injection/intercepted/InterceptedBeanInitializerInjectionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/injection/intercepted/InterceptedBeanInitializerInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/injection/intercepted/InterceptedConstructorInjector.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/injection/intercepted/InterceptedConstructorInjector.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/injection/intercepted/InterceptedFieldInjector.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/injection/intercepted/InterceptedFieldInjector.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/injection/intercepted/InterceptedInitializerInjector.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/injection/intercepted/InterceptedInitializerInjector.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/BeanTypeParamConstructorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/BeanTypeParamConstructorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/BeanTypeParamDisposerTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/BeanTypeParamDisposerTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/BeanTypeParamFieldTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/BeanTypeParamFieldTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/BeanTypeParamInitializerTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/BeanTypeParamInitializerTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/BeanTypeParamProducerTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/BeanTypeParamProducerTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/Cream.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/Cream.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/Milk.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/Milk.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/MilkDisposer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/MilkDisposer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/MilkProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/MilkProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/YoghurtConstructor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/YoghurtConstructor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/YoghurtField.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/YoghurtField.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/YoghurtInitializer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/YoghurtInitializer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/interceptor/Binding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/interceptor/Binding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/interceptor/InterceptedBeanConstructor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/interceptor/InterceptedBeanConstructor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/interceptor/InterceptedBeanField.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/interceptor/InterceptedBeanField.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/interceptor/InterceptedBeanInitializer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/interceptor/InterceptedBeanInitializer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/interceptor/InterceptedBeanTypeParamConstructorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/interceptor/InterceptedBeanTypeParamConstructorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/interceptor/InterceptedBeanTypeParamFieldTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/interceptor/InterceptedBeanTypeParamFieldTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/interceptor/InterceptedBeanTypeParamInitializerTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/interceptor/InterceptedBeanTypeParamInitializerTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/interceptor/InterceptorConstructor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/interceptor/InterceptorConstructor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/interceptor/InterceptorField.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/interceptor/InterceptorField.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/interceptor/InterceptorInitializer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/interceptor/InterceptorInitializer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/interceptor/InterceptorTypeParamConstructorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/interceptor/InterceptorTypeParamConstructorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/interceptor/InterceptorTypeParamFieldTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/interceptor/InterceptorTypeParamFieldTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/interceptor/InterceptorTypeParamInitializerTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/broken/typeparam/interceptor/InterceptorTypeParamInitializerTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/Calisoga.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/Calisoga.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/Deadliest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/Deadliest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/DeadlyAnimal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/DeadlyAnimal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/DeadlySpider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/DeadlySpider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/DefangedTarantula.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/DefangedTarantula.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/DisposalMethodDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/DisposalMethodDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/DisposalNonBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/DisposalNonBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/SandSpider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/SandSpider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/Scary.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/Scary.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/Spider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/Spider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/SpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/SpiderProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/Tarantula.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/Tarantula.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/WebSpider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/WebSpider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/Widow.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/Widow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/initializerUnallowed/InitializerUnallowedDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/initializerUnallowed/InitializerUnallowedDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/initializerUnallowed/Spider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/initializerUnallowed/Spider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/initializerUnallowed/SpiderProducer_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/initializerUnallowed/SpiderProducer_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/interceptor/DisposerMethodOnInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/interceptor/DisposerMethodOnInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/interceptor/FooProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/interceptor/FooProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/interceptor/ProducedString.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/interceptor/ProducedString.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/interceptor/Secure.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/interceptor/Secure.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/interceptor/SimpleInterceptor_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/interceptor/SimpleInterceptor_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/multiParams/MultipleDisposeParametersDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/multiParams/MultipleDisposeParametersDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/multiParams/Spider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/multiParams/Spider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/multiParams/SpiderProducer_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/multiParams/SpiderProducer_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/multiple/Bus.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/multiple/Bus.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/multiple/BusFactory.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/multiple/BusFactory.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/multiple/MultipleDisposerMethodsForProducerMethodTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/multiple/MultipleDisposerMethodsForProducerMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/multiple/Vehicle.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/multiple/Vehicle.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/observes/ObserverParameterUnallowedDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/observes/ObserverParameterUnallowedDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/observes/Spider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/observes/Spider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/observes/SpiderProducer_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/observes/SpiderProducer_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/producesUnallowed/ProducesUnallowedDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/producesUnallowed/ProducesUnallowedDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/producesUnallowed/Spider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/producesUnallowed/Spider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/producesUnallowed/SpiderProducer_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/producesUnallowed/SpiderProducer_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/unresolvedMethod/Cat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/unresolvedMethod/Cat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/unresolvedMethod/Spider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/unresolvedMethod/Spider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/unresolvedMethod/SpiderProducer_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/unresolvedMethod/SpiderProducer_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/unresolvedMethod/UnresolvedDisposalMethodDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/unresolvedMethod/UnresolvedDisposalMethodDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/validation/ambiguous/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/validation/ambiguous/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/validation/ambiguous/Cow.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/validation/ambiguous/Cow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/validation/ambiguous/DisposerMethodParameterInjectionValidationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/validation/ambiguous/DisposerMethodParameterInjectionValidationTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/validation/ambiguous/Producer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/validation/ambiguous/Producer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/validation/ambiguous/Product.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/validation/ambiguous/Product.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/validation/unsatisfied/DisposerMethodParameterInjectionValidationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/validation/unsatisfied/DisposerMethodParameterInjectionValidationTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/validation/unsatisfied/Producer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/validation/unsatisfied/Producer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/validation/unsatisfied/Product.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/validation/unsatisfied/Product.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/Apple.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/Apple.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/AppleTree.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/AppleTree.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/Chef.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/Chef.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/Cook.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/Cook.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/DisposerMethodInheritanceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/DisposerMethodInheritanceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/GrannySmithAppleTree.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/GrannySmithAppleTree.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/GreatGrannySmithAppleTree.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/GreatGrannySmithAppleTree.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/Meal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/Meal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/Yummy.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/Yummy.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/invocation/DisposesMethodCalledOnceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/invocation/DisposesMethodCalledOnceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/invocation/DummyQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/invocation/DummyQualifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/invocation/FirstBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/invocation/FirstBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/invocation/ProducerBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/invocation/ProducerBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/invocation/SecondBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/invocation/SecondBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/invocation/TestObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/invocation/TestObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/parameters/DisposedParameterPositionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/parameters/DisposedParameterPositionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/parameters/Idea.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/parameters/Idea.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/parameters/IdeaFactory.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/parameters/IdeaFactory.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/parameters/Thinker.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/parameters/Thinker.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/Chicken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/Chicken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/ChickenHutch.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/ChickenHutch.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/ChickenInterface.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/ChickenInterface.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/Fox.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/Fox.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/InitializerMethodTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/InitializerMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/Preferred.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/Preferred.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/PreferredChicken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/PreferredChicken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/PremiumChickenHutch.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/PremiumChickenHutch.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/StandardChicken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/StandardChicken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/StandardChickenHutch.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/StandardChickenHutch.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/StandardVariety.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/StandardVariety.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/generic/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/generic/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/generic/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/generic/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/generic/GenericInitializerMethodTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/generic/GenericInitializerMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/methodAnnotatedProduces/InitializerMethodAnnotatedProducesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/methodAnnotatedProduces/InitializerMethodAnnotatedProducesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/methodAnnotatedProduces/Pheasant_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/methodAnnotatedProduces/Pheasant_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedAsyncObserves/Food.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedAsyncObserves/Food.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedAsyncObserves/FoodConsumer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedAsyncObserves/FoodConsumer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedAsyncObserves/ParameterAnnotatedAsyncObservesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedAsyncObserves/ParameterAnnotatedAsyncObservesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedDisposes/Capercaillie_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedDisposes/Capercaillie_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedDisposes/ChickenHutch.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedDisposes/ChickenHutch.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedDisposes/ParameterAnnotatedDisposesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedDisposes/ParameterAnnotatedDisposesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedObserves/DangerCall.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedObserves/DangerCall.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedObserves/Grouse_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedObserves/Grouse_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedObserves/ParameterAnnotatedObservesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/broken/parameterAnnotatedObserves/ParameterAnnotatedObservesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/AsAnimal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/AsAnimal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/BlackWidow.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/BlackWidow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/BlackWidowProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/BlackWidowProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Chicken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Chicken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/DaddyLongLegs.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/DaddyLongLegs.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/DeadlyAnimal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/DeadlyAnimal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/DeadlySpider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/DeadlySpider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/DefangedTarantula.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/DefangedTarantula.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Egg.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Egg.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/FunnelWeaver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/FunnelWeaver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/FunnelWeaverSpiderConsumer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/FunnelWeaverSpiderConsumer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/FunnelWeaverSpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/FunnelWeaverSpiderProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/InfertileChicken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/InfertileChicken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/LadybirdSpider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/LadybirdSpider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/LameInfertileChicken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/LameInfertileChicken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/OtherSpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/OtherSpiderProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Pet.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Pet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/ProducerFieldDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/ProducerFieldDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Spider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Spider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/SpiderAsAnimalProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/SpiderAsAnimalProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/SpiderListProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/SpiderListProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/SpiderStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/SpiderStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Spidery.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Spidery.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Static.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Static.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/StaticTarantulaProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/StaticTarantulaProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/TameTarantulaProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/TameTarantulaProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Tarantula.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/Tarantula.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/TarantulaProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/TarantulaProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/WolfSpider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/WolfSpider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/array/ParameterizedTypeWithWildcardBrokenProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/array/ParameterizedTypeWithWildcardBrokenProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/array/ProducerFieldArrayTypeVariableTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/array/ProducerFieldArrayTypeVariableTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/array/ProducerFieldArrayWildcardTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/array/ProducerFieldArrayWildcardTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/array/TypeVariableBrokenProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/array/TypeVariableBrokenProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/inject/FooProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/inject/FooProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/inject/InjectAnnotatedProducerFieldTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/inject/InjectAnnotatedProducerFieldTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/interceptor/Number.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/interceptor/Number.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/interceptor/ProducerFieldOnInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/interceptor/ProducerFieldOnInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/interceptor/Secure.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/interceptor/Secure.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/interceptor/SimpleInterceptor_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/interceptor/SimpleInterceptor_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/typeVariable/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/typeVariable/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/typeVariable/ProducerFieldWithTypeVariableTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/typeVariable/ProducerFieldWithTypeVariableTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/typeVariable2/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/typeVariable2/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/typeVariable2/RequestScopedProducerFieldWithTypeVariableTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/typeVariable2/RequestScopedProducerFieldWithTypeVariableTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/wildcard/FunnelWeaver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/wildcard/FunnelWeaver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/wildcard/ProducerFieldTypeWithWildcardTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/wildcard/ProducerFieldTypeWithWildcardTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/wildcard/SpiderProducerWildCardType_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/wildcard/SpiderProducerWildCardType_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/BlackWidow.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/BlackWidow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/BlackWidowConsumer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/BlackWidowConsumer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/BlackWidowProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/BlackWidowProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/BrownRecluse.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/BrownRecluse.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/BrownRecluseProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/BrownRecluseProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/DeadlyAnimal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/DeadlyAnimal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/DeadlySpider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/DeadlySpider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/Null.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/Null.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/NullSpiderConsumer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/NullSpiderConsumer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/NullSpiderConsumerForBrokenProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/NullSpiderConsumerForBrokenProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/NullSpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/NullSpiderProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/NullSpiderProducer_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/NullSpiderProducer_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/ProducerFieldLifecycleTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/ProducerFieldLifecycleTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/Spider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/Spider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/SpiderStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/SpiderStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/Static.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/Static.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/StaticTarantulaConsumer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/StaticTarantulaConsumer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/StaticTarantulaProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/StaticTarantulaProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/Tarantula.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/Tarantula.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/Working.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/lifecycle/Working.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/array/ParameterizedTypeWithWildcardBrokenProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/array/ParameterizedTypeWithWildcardBrokenProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/array/ProducerMethodArrayTypeVariableTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/array/ProducerMethodArrayTypeVariableTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/array/ProducerMethodArrayWildcardTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/array/ProducerMethodArrayWildcardTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/array/TypeVariableBrokenProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/array/TypeVariableBrokenProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/interceptor/Number.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/interceptor/Number.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/interceptor/ProducerMethodOnInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/interceptor/ProducerMethodOnInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/interceptor/Secure.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/interceptor/Secure.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/interceptor/SimpleInterceptor_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/interceptor/SimpleInterceptor_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterAnnotatedDisposes/ParameterAnnotatedDisposesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterAnnotatedDisposes/ParameterAnnotatedDisposesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterAnnotatedDisposes/SpiderProducer_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterAnnotatedDisposes/SpiderProducer_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterAnnotatedObserves/ParameterAnnotatedObservesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterAnnotatedObserves/ParameterAnnotatedObservesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterAnnotatedObserves/SpiderProducer_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterAnnotatedObserves/SpiderProducer_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterAnnotatedObservesAsync/BrokenProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterAnnotatedObservesAsync/BrokenProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterAnnotatedObservesAsync/ParameterAnnotatedAsyncObservesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterAnnotatedObservesAsync/ParameterAnnotatedAsyncObservesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithTypeParameter/DoubleListProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithTypeParameter/DoubleListProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithTypeParameter/GeneralListProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithTypeParameter/GeneralListProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithTypeParameter/ParameterizedReturnTypeWithTypeVariableTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithTypeParameter/ParameterizedReturnTypeWithTypeVariableTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithTypeParameter/ParametrizedReturnTypeWithTypeVariable02Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithTypeParameter/ParametrizedReturnTypeWithTypeVariable02Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithWildcard/FunnelWeaver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithWildcard/FunnelWeaver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithWildcard/ParameterizedTypeWithWildcardTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithWildcard/ParameterizedTypeWithWildcardTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithWildcard/ParametrizedTypeWithWildcard02Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithWildcard/ParametrizedTypeWithWildcard02Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithWildcard/SpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithWildcard/SpiderProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithWildcard/Spiderman.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithWildcard/Spiderman.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithWildcard/SpidermanProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/parameterizedTypeWithWildcard/SpidermanProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/typeVariableReturnType/TProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/typeVariableReturnType/TProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/typeVariableReturnType/TypeVariableReturnTypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/typeVariableReturnType/TypeVariableReturnTypeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Acorn.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Acorn.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/AnimalStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/AnimalStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Apple.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Apple.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/AppleTree.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/AppleTree.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/BeanWithStaticProducerMethod.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/BeanWithStaticProducerMethod.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Bite.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Bite.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/BlackWidow.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/BlackWidow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Cherry.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Cherry.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/DaddyLongLegs.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/DaddyLongLegs.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Deadliest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Deadliest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/DeadlyAnimal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/DeadlyAnimal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/DeadlySpider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/DeadlySpider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/DefangedTarantula.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/DefangedTarantula.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/FunnelWeaver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/FunnelWeaver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/GeneralListProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/GeneralListProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/GrannySmithAppleTree.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/GrannySmithAppleTree.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/GreatGrannySmithAppleTree.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/GreatGrannySmithAppleTree.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/LadybirdSpider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/LadybirdSpider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/NonBeanWithStaticProducerMethod.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/NonBeanWithStaticProducerMethod.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Number.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Number.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/OakTree.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/OakTree.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Pollen.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Pollen.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/ProducerMethodDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/ProducerMethodDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Spider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Spider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/SpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/SpiderProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Tarantula.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Tarantula.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/WolfSpider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/WolfSpider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Yummy.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/Yummy.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/name/Bug.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/name/Bug.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/name/BugProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/name/BugProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/name/BugStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/name/BugStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/name/Crazy.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/name/Crazy.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/name/Funny.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/name/Funny.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/name/ProducerMethodWithDefaultNameTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/name/ProducerMethodWithDefaultNameTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/BrownRecluse.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/BrownRecluse.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Chicken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Chicken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/DeadlyAnimal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/DeadlyAnimal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/DeadlySpider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/DeadlySpider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Delicious.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Delicious.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Egg.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Egg.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Fail.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Fail.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/FirstBorn.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/FirstBorn.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/FooException.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/FooException.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Lays.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Lays.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Lorry.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Lorry.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/LorryProducer_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/LorryProducer_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Null.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Null.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Pet.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Pet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/PotatoChip.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/PotatoChip.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/ProducerMethodLifecycleTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/ProducerMethodLifecycleTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Request.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Request.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Ship.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Ship.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/ShipProducer_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/ShipProducer_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Spider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Spider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/SpiderEgg.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/SpiderEgg.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/SpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/SpiderProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/SpiderProducer_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/SpiderProducer_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Tarantula.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Tarantula.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Web.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/lifecycle/Web.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/Antelope_NotBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/Antelope_NotBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/Car.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/Car.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/ClovenHoved.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/ClovenHoved.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/Cow_NotBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/Cow_NotBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/Donkey.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/Donkey.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/OuterClass.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/OuterClass.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/Sheep.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/Sheep.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/SimpleBeanDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/SimpleBeanDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/SimpleExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/SimpleExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/SnowTiger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/SnowTiger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/Tiger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/Tiger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/Turkey.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/Turkey.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/White.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/White.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/broken/field/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/broken/field/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/broken/field/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/broken/field/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/broken/field/InjectedFieldAnnotatedWithProducesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/broken/field/InjectedFieldAnnotatedWithProducesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/constructorHasAsyncObservesParameter/ConstructorHasAsyncObservesParameterTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/constructorHasAsyncObservesParameter/ConstructorHasAsyncObservesParameterTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/constructorHasAsyncObservesParameter/Food.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/constructorHasAsyncObservesParameter/Food.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/constructorHasAsyncObservesParameter/FoodConsumerBroken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/constructorHasAsyncObservesParameter/FoodConsumerBroken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/constructorHasDisposesParameter/ConstructorHasDisposesParameterTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/constructorHasDisposesParameter/ConstructorHasDisposesParameterTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/constructorHasDisposesParameter/DisposingConstructor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/constructorHasDisposesParameter/DisposingConstructor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/constructorHasDisposesParameter/Duck.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/constructorHasDisposesParameter/Duck.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/constructorHasObservesParameter/ConstructorHasObservesParameterTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/constructorHasObservesParameter/ConstructorHasObservesParameterTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/constructorHasObservesParameter/Duck.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/constructorHasObservesParameter/Duck.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/constructorHasObservesParameter/ObservingConstructor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/constructorHasObservesParameter/ObservingConstructor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/normalScopedWithPublicField/Leopard_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/normalScopedWithPublicField/Leopard_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/normalScopedWithPublicField/NormalScopedWithPublicFieldTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/normalScopedWithPublicField/NormalScopedWithPublicFieldTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/normalScopedWithPublicStaticField/Leopard.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/normalScopedWithPublicStaticField/Leopard.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/normalScopedWithPublicStaticField/NormalScopedWithPublicStaticFieldTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/normalScopedWithPublicStaticField/NormalScopedWithPublicStaticFieldTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/tooManyInitializerAnnotatedConstructors/Goose_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/tooManyInitializerAnnotatedConstructors/Goose_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/tooManyInitializerAnnotatedConstructors/TooManyInitializerAnnotatedConstructorsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/tooManyInitializerAnnotatedConstructors/TooManyInitializerAnnotatedConstructorsTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/BookOrderProcessor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/BookOrderProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/CdOrderProcessor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/CdOrderProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Cod.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Cod.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Duck.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Duck.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Egg.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Egg.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/EggProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/EggProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Farm.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Farm.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/FarmOffice.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/FarmOffice.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/FishPond.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/FishPond.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/FishStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/FishStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/FooException.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/FooException.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Goldfish.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Goldfish.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Goose.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Goose.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/IndirectOrderProcessor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/IndirectOrderProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/IntermediateOrderProcessor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/IntermediateOrderProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Lorry_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Lorry_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/NovelOrderProcessor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/NovelOrderProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/OrderProcessor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/OrderProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/RedSnapper.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/RedSnapper.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/RequestScopedAnimalStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/RequestScopedAnimalStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Salmon.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Salmon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/ShoeFactory.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/ShoeFactory.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/SimpleBeanLifecycleTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/SimpleBeanLifecycleTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Synchronous.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Synchronous.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Tuna.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Tuna.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/TunaFarm.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/TunaFarm.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/TunaProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/TunaProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Van_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/Van_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/unproxyable/UnproxyableBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/unproxyable/UnproxyableBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/unproxyable/UnproxyableBeanWithPackagePrivateFinalMethod.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/unproxyable/UnproxyableBeanWithPackagePrivateFinalMethod.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/unproxyable/UnproxyableBeanWithProtectedFinalMethod.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/unproxyable/UnproxyableBeanWithProtectedFinalMethod.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/unproxyable/UnproxyableBeanWithPublicFinalMethod.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/unproxyable/UnproxyableBeanWithPublicFinalMethod.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/unproxyable/UnproxyableFinalClass.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/unproxyable/UnproxyableFinalClass.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/unproxyable/UnproxyableManagedBeanTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/lifecycle/unproxyable/UnproxyableManagedBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/inheritance/generics/Amazing.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/inheritance/generics/Amazing.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/inheritance/generics/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/inheritance/generics/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/inheritance/generics/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/inheritance/generics/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/inheritance/generics/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/inheritance/generics/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/inheritance/generics/MemberLevelInheritanceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/inheritance/generics/MemberLevelInheritanceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/inheritance/generics/Producer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/inheritance/generics/Producer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/inheritance/generics/Qux.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/inheritance/generics/Qux.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/AccountTransaction.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/AccountTransaction.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/Atomic.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/Atomic.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/AtomicFoo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/AtomicFoo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/AtomicInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/AtomicInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/FileLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/FileLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/InterceptorDefinitionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/InterceptorDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/Loggable.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/Loggable.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/Logged.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/Logged.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/MissileBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/MissileBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/MissileInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/MissileInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/NetworkLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/NetworkLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/NonBindingType.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/NonBindingType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/NotEnabledAtomicInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/NotEnabledAtomicInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/Secure.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/Secure.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/SecureInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/SecureInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/SecureTransaction.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/SecureTransaction.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/ShoppingCart.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/ShoppingCart.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/Transactional.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/Transactional.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/TransactionalInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/TransactionalInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/AntiAircraftIPBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/AntiAircraftIPBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/AntiAircraftMissileFinalClass.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/AntiAircraftMissileFinalClass.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/DependentBeanFinalMethodInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/DependentBeanFinalMethodInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/FinalClassClassLevelIPBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/FinalClassClassLevelIPBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/FinalClassClassLevelInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/FinalClassClassLevelInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/FinalClassClassLevelMissile.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/FinalClassClassLevelMissile.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/FinalClassMethodLevelIPBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/FinalClassMethodLevelIPBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/FinalClassMethodLevelMissile.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/FinalClassMethodLevelMissile.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/FooBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/FooBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/MissileInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/MissileInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/NormalScopedBeanFinalClassInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/NormalScopedBeanFinalClassInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/NormalScopedBeanFinalMethodInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/NormalScopedBeanFinalMethodInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/NuclearMissileFinalMethod.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/NuclearMissileFinalMethod.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/NuclearMissileIPBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/NuclearMissileIPBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/SurfaceToAirIPBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/SurfaceToAirIPBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/SurfaceToAirMissileFinalMethod.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/SurfaceToAirMissileFinalMethod.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/nonDependent/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/nonDependent/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/nonDependent/NonDependentInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/nonDependent/NonDependentInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/nonDependent/NonDependentInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/nonDependent/NonDependentInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/nonDependent/SomeBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/nonDependent/SomeBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/observer/FooPayload.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/observer/FooPayload.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/observer/InterceptorWithObserverMethodTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/observer/InterceptorWithObserverMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/observer/Transactional.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/observer/Transactional.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/observer/TransactionalInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/observer/TransactionalInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/observer/TransactionalService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/observer/TransactionalService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/observer/async/InterceptorWithAsyncObserverMethodTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/observer/async/InterceptorWithAsyncObserverMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/observer/async/Transactional.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/observer/async/Transactional.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/observer/async/TransactionalInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/observer/async/TransactionalInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/observer/async/TransactionalService.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/observer/async/TransactionalService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/Culinary.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/Culinary.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/European.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/European.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/EuropeanLarch.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/EuropeanLarch.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/GuardedBySquirrel.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/GuardedBySquirrel.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/GuardedByWoodpecker.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/GuardedByWoodpecker.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/Herb.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/Herb.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/InterceptorBindingInheritanceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/InterceptorBindingInheritanceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/Larch.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/Larch.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/Ping.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/Ping.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/Plant.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/Plant.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/PongPlant.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/PongPlant.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/Rosehip.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/Rosehip.java
@@ -4,8 +4,6 @@ import jakarta.enterprise.context.Dependent;
 
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/Shrub.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/Shrub.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/SquirrelInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/SquirrelInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/Thyme.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/Thyme.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/Tree.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/Tree.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/WoodpeckerInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/WoodpeckerInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/Airbus.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/Airbus.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/Boeing.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/Boeing.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/Fighter.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/Fighter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/FighterStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/FighterStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/FinalClassWithInheritedClassLevelInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/FinalClassWithInheritedClassLevelInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/FinalClassWithInheritedStereotypeInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/FinalClassWithInheritedStereotypeInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/FinalMethodWithInheritedClassLevelInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/FinalMethodWithInheritedClassLevelInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/FinalMethodWithInheritedStereotypeInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/FinalMethodWithInheritedStereotypeInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/Jumbojet.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/Jumbojet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/LandingBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/LandingBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/LandingInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/LandingInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/Messerschmitt.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/Messerschmitt.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/Spitfire.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance/broken/binding/Spitfire.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/interceptorOrder/FirstInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/interceptorOrder/FirstInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/interceptorOrder/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/interceptorOrder/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/interceptorOrder/InterceptorOrderTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/interceptorOrder/InterceptorOrderTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/interceptorOrder/SecondInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/interceptorOrder/SecondInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/interceptorOrder/Secure.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/interceptorOrder/Secure.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/member/AnimalCountInterceptorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/member/AnimalCountInterceptorBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/member/DecreasingInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/member/DecreasingInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/member/Farm.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/member/Farm.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/member/IncreasingInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/member/IncreasingInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/member/InterceptorBindingTypeWithMemberTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/member/InterceptorBindingTypeWithMemberTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/member/VehicleCountInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/member/VehicleCountInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/member/VehicleCountInterceptorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/member/VehicleCountInterceptorBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/invocation/AlmightyBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/invocation/AlmightyBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/invocation/AlmightyInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/invocation/AlmightyInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/invocation/InterceptorInvocationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/invocation/InterceptorInvocationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/invocation/Missile.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/invocation/Missile.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/invocation/MissileObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/invocation/MissileObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/invocation/Rye.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/invocation/Rye.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/invocation/Warhead.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/invocation/Warhead.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/invocation/Watcher.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/invocation/Watcher.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/invocation/Wheat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/invocation/Wheat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/invocation/WheatProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/invocation/WheatProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/binding/members/annotation/BindingAnnotationWithMemberTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/binding/members/annotation/BindingAnnotationWithMemberTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/binding/members/annotation/Expensive.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/binding/members/annotation/Expensive.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/binding/members/annotation/SimpleAnnotation.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/binding/members/annotation/SimpleAnnotation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/binding/members/annotation/TheBeatles.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/binding/members/annotation/TheBeatles.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/binding/members/annotation/Watch.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/binding/members/annotation/Watch.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/binding/members/array/BindingAnnotationWithMemberTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/binding/members/array/BindingAnnotationWithMemberTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/binding/members/array/Expensive.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/binding/members/array/Expensive.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/binding/members/array/TheBeatles.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/binding/members/array/TheBeatles.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/binding/members/array/Watch.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/binding/members/array/Watch.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/Cod.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/Cod.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/Plaice.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/Plaice.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/ResolutionByNameTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/ResolutionByNameTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/Salmon.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/Salmon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/Sole.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/Sole.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/Whitefish.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/Whitefish.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/ambiguous/AmbiguousELNamesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/ambiguous/AmbiguousELNamesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/ambiguous/FishProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/ambiguous/FishProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/ambiguous/Salmon.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/ambiguous/Salmon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/ambiguous/Sole.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/ambiguous/Sole.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/ambiguous/broken/AmbiguousELNamesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/ambiguous/broken/AmbiguousELNamesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/ambiguous/broken/FishProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/ambiguous/broken/FishProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/ambiguous/broken/Salmon.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/ambiguous/broken/Salmon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/ambiguous/broken/Sole.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/ambiguous/broken/Sole.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/duplicity/Cod.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/duplicity/Cod.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/duplicity/DuplicitNameTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/duplicity/DuplicitNameTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/duplicity/Sole.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/duplicity/Sole.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed/NamedNonFieldInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed/NamedNonFieldInjectionPointTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed2/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed2/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed2/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed2/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed2/NamedNonFieldInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed2/NamedNonFieldInjectionPointTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed3/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed3/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed3/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed3/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed3/NamedNonFieldInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/injectionPointWithNamed3/NamedNonFieldInjectionPointTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/prefix/Example.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/prefix/Example.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/prefix/ExampleWebsite_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/prefix/ExampleWebsite_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/prefix/ExpandedNamePrefix2Test.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/prefix/ExpandedNamePrefix2Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/prefix/ExpandedNamePrefixTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/prefix/ExpandedNamePrefixTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/prefix/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/prefix/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/prefix/FooBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/prefix/FooBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/prefix/FooBarBaz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/prefix/FooBarBaz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/prefix/NamePrefixTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/byname/broken/prefix/NamePrefixTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/Air.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/Air.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/Bird.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/Bird.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/Car.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/Car.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/CircularDependencyTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/CircularDependencyTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/DependentSelfConsumingNormalProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/DependentSelfConsumingNormalProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/Food.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/Food.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/House.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/House.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/NormalSelfConsumingNormalProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/NormalSelfConsumingNormalProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/Petrol.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/Petrol.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/Pig.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/Pig.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/Planet.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/Planet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/SelfConsumingDependent1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/SelfConsumingDependent1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/SelfConsumingNormal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/SelfConsumingNormal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/SelfConsumingNormal1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/SelfConsumingNormal1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/Space.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/Space.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/Violation.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/circular/Violation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/ClientProxyTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/ClientProxyTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/Fox.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/Fox.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/Tuna.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/Tuna.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/TunedTuna.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/TunedTuna.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/array/ArrayProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/array/ArrayProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/array/ArrayTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/array/ArrayTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/array/InjectionPointBean_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/array/InjectionPointBean_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/beanConstructor/BeanConstructorWithParametersTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/beanConstructor/BeanConstructorWithParametersTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/beanConstructor/InjectionPointBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/beanConstructor/InjectionPointBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/beanConstructor/Unproxyable_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/beanConstructor/Unproxyable_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalClass/FinalClassTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalClass/FinalClassTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalClass/FishFarm.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalClass/FishFarm.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalClass/Tuna_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalClass/Tuna_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/CarpBroken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/CarpBroken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/CarpFarm.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/CarpFarm.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/ExtendedFishFarm.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/ExtendedFishFarm.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/ExtendedTuna_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/ExtendedTuna_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/FishFarm.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/FishFarm.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/NonPrivateNonStaticSuperclassMethodTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/NonPrivateNonStaticSuperclassMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/PackagePrivateFinalMethodNotProxyableTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/PackagePrivateFinalMethodNotProxyableTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/PikeBroken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/PikeBroken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/PikeFarm.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/PikeFarm.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/PrivateFinalMethodTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/PrivateFinalMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/ProtectedFinalMethodNotProxyableTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/ProtectedFinalMethodNotProxyableTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/PublicFinalMethodNotProxyableTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/PublicFinalMethodNotProxyableTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/StaticFinalMethodTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/StaticFinalMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/Tuna.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/Tuna.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/TunaFarm.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/TunaFarm.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/Tuna_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/Tuna_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/Whale.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/Whale.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/WhaleCovey.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/finalMethod/WhaleCovey.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/interceptor/Fish.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/interceptor/Fish.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/interceptor/FishInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/interceptor/FishInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/interceptor/InterceptedBeanProxyTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/interceptor/InterceptedBeanProxyTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/interceptor/TestBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/interceptor/TestBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/interceptor/Tuna.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/interceptor/Tuna.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/primitive/NumberProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/primitive/NumberProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/primitive/Number_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/primitive/Number_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/primitive/UnproxyableTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/primitive/UnproxyableTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/privateConstructor/InjectionPointBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/privateConstructor/InjectionPointBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/privateConstructor/PrivateConstructorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/privateConstructor/PrivateConstructorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/privateConstructor/Unproxyable_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/privateConstructor/Unproxyable_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/AmbiguousDependencyResolutionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/AmbiguousDependencyResolutionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/BarProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/BarProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/FooProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/FooProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/ambiguous/AmbiguousDependencyTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/ambiguous/AmbiguousDependencyTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/ambiguous/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/ambiguous/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/ambiguous/Cow.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/ambiguous/Cow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/ambiguous/Farm_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/ambiguous/Farm_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/ambiguous/Sheep.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/ambiguous/Sheep.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/unsatisfied/Bean_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/unsatisfied/Bean_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/unsatisfied/Small.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/unsatisfied/Small.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/unsatisfied/UnsatisfiedDependencyTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/unsatisfied/UnsatisfiedDependencyTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/unsatisfied/Vanilla.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/unsatisfied/Vanilla.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/AdvancedPaymentProcessor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/AdvancedPaymentProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/AsynchronousPaymentProcessor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/AsynchronousPaymentProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/Common.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/Common.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/Corge.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/Corge.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/DynamicLookupTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/DynamicLookupTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/Garply.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/Garply.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/NonBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/NonBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/ObtainsInstanceBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/ObtainsInstanceBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/PayBy.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/PayBy.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/PayByBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/PayByBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/PaymentProcessor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/PaymentProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/RemotePaymentProcessor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/RemotePaymentProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/SimplePaymentProcessor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/SimplePaymentProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/SynchronousPaymentProcessor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/SynchronousPaymentProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/Uncommon.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/Uncommon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/raw/ConstructorInjectionBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/raw/ConstructorInjectionBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/raw/DisposerMethodInjectionBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/raw/DisposerMethodInjectionBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/raw/FieldInjectionBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/raw/FieldInjectionBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/raw/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/raw/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/raw/InitMethodInjectionBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/raw/InitMethodInjectionBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/raw/ObserverInjectionBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/raw/ObserverInjectionBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/raw/ProducerMethodInjectionBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/raw/ProducerMethodInjectionBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/raw/RawInstanceConstructorInjectionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/raw/RawInstanceConstructorInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/raw/RawInstanceDisposerInjectionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/raw/RawInstanceDisposerInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/raw/RawInstanceFieldInjectionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/raw/RawInstanceFieldInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/raw/RawInstanceInitMethodInjectionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/raw/RawInstanceInitMethodInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/raw/RawInstanceObserverInjectionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/raw/RawInstanceObserverInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/raw/RawInstanceProducerMethodInjectionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/broken/raw/RawInstanceProducerMethodInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/builtin/AbstractAnimal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/builtin/AbstractAnimal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/builtin/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/builtin/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/builtin/BuiltinInstanceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/builtin/BuiltinInstanceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/builtin/Cow.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/builtin/Cow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/builtin/Farm.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/builtin/Farm.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/builtin/FarmBased.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/builtin/FarmBased.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/builtin/Field.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/builtin/Field.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/builtin/FinalAnimal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/builtin/FinalAnimal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/builtin/Predator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/builtin/Predator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/builtin/Sheep.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/builtin/Sheep.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/builtin/Wolf.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/builtin/Wolf.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/destroy/dependent/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/destroy/dependent/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/destroy/dependent/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/destroy/dependent/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/destroy/dependent/DestroyingDependentInstanceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/destroy/dependent/DestroyingDependentInstanceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/destroy/dependent/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/destroy/dependent/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/destroy/dependent/Qux.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/destroy/dependent/Qux.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/destroy/dependent/Transactional.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/destroy/dependent/Transactional.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/destroy/dependent/TransactionalInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/destroy/dependent/TransactionalInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/destroy/normal/AbstractComponent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/destroy/normal/AbstractComponent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/destroy/normal/ApplicationScopedComponent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/destroy/normal/ApplicationScopedComponent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/destroy/normal/DestroyingNormalScopedInstanceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/destroy/normal/DestroyingNormalScopedInstanceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/destroy/normal/RequestScopedComponent.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/destroy/normal/RequestScopedComponent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Alpha.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Alpha.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Bravo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Bravo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Client.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Client.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/FirstProcessor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/FirstProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/InstanceHandleTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/InstanceHandleTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Juicy.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Juicy.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Processor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/Processor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/SecondProcessor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/dynamic/handle/SecondProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/Fox.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/Fox.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/Hen.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/Hen.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/ProducedInteger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/ProducedInteger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/SpiderNest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/SpiderNest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/SpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/SpiderProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/Wolf.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/Wolf.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/WolfPack.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/WolfPack.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/any/AnyInjectionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/any/AnyInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/any/Customer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/any/Customer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/any/Drink.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/any/Drink.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/ConsumerActualType.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/ConsumerActualType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/ConsumerRaw.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/ConsumerRaw.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/ConsumerRawObject.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/ConsumerRawObject.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/ConsumerTypeVariable.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/ConsumerTypeVariable.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/ConsumerTypeVariableUpperBound.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/ConsumerTypeVariableUpperBound.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/ConsumerWildcard.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/ConsumerWildcard.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/Dao.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/Dao.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/DaoProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/DaoProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/IntegerDao.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/IntegerDao.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/IntegerListOfStringsDao.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/IntegerListOfStringsDao.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/IntegerPowered.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/IntegerPowered.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/IntegerStringDao.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/IntegerStringDao.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/NumberDao.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/NumberDao.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/ObjectDao.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/ObjectDao.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/ObjectPowered.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/ObjectPowered.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/ParameterizedTypesInjectionToParameterizedWithActualTypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/ParameterizedTypesInjectionToParameterizedWithActualTypeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/ParameterizedTypesInjectionToParameterizedWithTypeVariableTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/ParameterizedTypesInjectionToParameterizedWithTypeVariableTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/ParameterizedTypesInjectionToParameterizedWithTypeVariableUpperBoundTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/ParameterizedTypesInjectionToParameterizedWithTypeVariableUpperBoundTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/ParameterizedTypesInjectionToParameterizedWithWildcardTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/ParameterizedTypesInjectionToParameterizedWithWildcardTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/ParameterizedTypesInjectionToRawTypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/ParameterizedTypesInjectionToRawTypeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/StringDao.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/StringDao.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/broken/raw/ParameterizedTypesInjectionRawAmbiguousTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/broken/raw/ParameterizedTypesInjectionRawAmbiguousTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/BarFooImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/BarFooImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/BarFooQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/BarFooQualifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/BarImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/BarImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/BazQualifier.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/BazQualifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/ConsumerMultipleBounds.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/ConsumerMultipleBounds.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/GenericInterface.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/GenericInterface.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/GenericInterfaceBarBazFooImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/GenericInterfaceBarBazFooImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/GenericInterfaceBarFooImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/GenericInterfaceBarFooImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/GenericInterfaceSuperBazImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/GenericInterfaceSuperBazImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/ParameterizedTypesWithTypeVariableWithMultipleBoundsTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/ParameterizedTypesWithTypeVariableWithMultipleBoundsTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/SuperBaz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/parameterized/multiple/bounds/SuperBaz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/BazProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/BazProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/BeanWithInjectionPointMetadata.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/BeanWithInjectionPointMetadata.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/ConstructorInjectionPointBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/ConstructorInjectionPointBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/FieldInjectionPointBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/FieldInjectionPointBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/InjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/InjectionPointTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/MethodInjectionPointBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/MethodInjectionPointBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/TransientFieldInjectionPointBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/TransientFieldInjectionPointBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/broken/disposer/DisposerInjectionPointMetadataTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/broken/disposer/DisposerInjectionPointMetadataTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/broken/disposer/Disposer_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/broken/disposer/Disposer_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/broken/disposer/Nice.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/broken/disposer/Nice.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/broken/normal/scope/Cat_Broken.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/broken/normal/scope/Cat_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/broken/normal/scope/NormalScopedBeanWithInjectionPoint.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/broken/normal/scope/NormalScopedBeanWithInjectionPoint.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/dynamic/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/dynamic/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/dynamic/DynamicInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/dynamic/DynamicInjectionPointTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/dynamic/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/dynamic/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/dynamic/Nice.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/dynamic/Nice.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/dynamic/NiceFoo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/dynamic/NiceFoo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/named/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/named/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/named/Carp.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/named/Carp.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/named/Daphnia.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/named/Daphnia.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/named/DaphniaProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/named/DaphniaProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/named/FishingNet.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/named/FishingNet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/named/NamedAtInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/named/NamedAtInjectionPointTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/named/Pike.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/named/Pike.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/requiredtype/Conifer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/requiredtype/Conifer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/requiredtype/Forest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/requiredtype/Forest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/requiredtype/Leaf.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/requiredtype/Leaf.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/requiredtype/LegalRequiredTypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/requiredtype/LegalRequiredTypeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/requiredtype/Needle.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/requiredtype/Needle.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/requiredtype/Spruce.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/requiredtype/Spruce.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/requiredtype/Tree.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/requiredtype/Tree.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/FishFarmOffice.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/FishFarmOffice.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/ManagerTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/ManagerTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/African.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/African.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/AnimalFarmer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/AnimalFarmer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Australian.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Australian.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Bird.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Bird.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Canary.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Canary.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Cat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Cat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Chunky.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Chunky.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/ChunkyLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/ChunkyLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Cod.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Cod.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/DaddyLongLegs.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/DaddyLongLegs.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/DeadlyAnimal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/DeadlyAnimal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/DeadlySpider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/DeadlySpider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/DomesticCat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/DomesticCat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Dove.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Dove.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Emu.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Emu.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/European.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/European.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Expensive.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Expensive.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/ExpensiveLiteral.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/ExpensiveLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Farmer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Farmer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/FlightlessBird.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/FlightlessBird.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Halibut.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Halibut.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/LadybirdSpider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/LadybirdSpider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Lion.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Lion.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Max.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Max.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Min.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Min.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Number.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Number.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/NumberProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/NumberProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Parrot.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Parrot.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/PetShop.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/PetShop.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Plaice.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Plaice.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/ResolutionByTypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/ResolutionByTypeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/RoundWhitefish.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/RoundWhitefish.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/ScottishFish.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/ScottishFish.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/ScottishFishFarmer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/ScottishFishFarmer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Sole.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Sole.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Spider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Spider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/SpiderProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/SpiderProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Tame.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Tarantula.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Tarantula.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Tuna.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Tuna.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Whitefish.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Whitefish.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Wild.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/Wild.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/broken/disabled/CrabSpider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/broken/disabled/CrabSpider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/broken/disabled/DisabledBeanNotAvailableForInjectionTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/broken/disabled/DisabledBeanNotAvailableForInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/broken/disabled/Sea.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/broken/disabled/Sea.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/broken/type/variable/Animal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/broken/type/variable/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/broken/type/variable/Farm.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/broken/type/variable/Farm.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/broken/type/variable/Sheep.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/broken/type/variable/Sheep.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/broken/type/variable/TypeVariableInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/broken/type/variable/TypeVariableInjectionPointTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/interceptor/Cat.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/interceptor/Cat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/interceptor/CatInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/interceptor/CatInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/interceptor/CatInterceptorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/interceptor/CatInterceptorBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/interceptor/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/interceptor/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/interceptor/InterceptorNotResolvedInterModuleTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/interceptor/InterceptorNotResolvedInterModuleTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/interceptor/InterceptorNotResolvedTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/interceptor/InterceptorNotResolvedTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/AssignabilityOfRawAndParameterizedTypesTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/AssignabilityOfRawAndParameterizedTypesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/BarBazImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/BarBazImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/BarBazSuperFooImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/BarBazSuperFooImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/BarSubBazFooImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/BarSubBazFooImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/Box.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/Box.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/BoxBarBazFooImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/BoxBarBazFooImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/Dao.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/Dao.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/DaoProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/DaoProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/InjectedBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/InjectedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/IntegerDao.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/IntegerDao.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/IntegerHashMap.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/IntegerHashMap.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/MapProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/MapProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/ObjectDao.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/ObjectDao.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/Result.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/Result.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/ResultImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/ResultImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/SubBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/SubBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/SubBaz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/SubBaz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/SuperBar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/SuperBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/SuperBarFooCloneable.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/SuperBarFooCloneable.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/SuperFoo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/SuperFoo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/raw/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/raw/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/raw/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/raw/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/raw/RawBeanTypeParameterizedRequiredTypeTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/raw/RawBeanTypeParameterizedRequiredTypeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/raw/RawProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/parameterized/raw/RawProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/primitive/Game.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/primitive/Game.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/primitive/PrimitiveInjectionPointTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/primitive/PrimitiveInjectionPointTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/primitive/PrimitiveProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/primitive/PrimitiveProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/primitive/ProducedPrimitive.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/primitive/ProducedPrimitive.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/AlternativeStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/AlternativeStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/BarInterceptor1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/BarInterceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/BarInterceptor2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/BarInterceptor2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/BarInterceptorBinding1.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/BarInterceptorBinding1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/BarInterceptorBinding2.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/BarInterceptorBinding2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/BazObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/BazObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/BootstrapSEContainerTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/BootstrapSEContainerTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Circle.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Circle.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Corge.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Corge.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/CorgeDecorator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/CorgeDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/CorgeImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/CorgeImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Custom.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Custom.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/FooProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/FooProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Garply.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Garply.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/GarplyProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/GarplyProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Qux.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Qux.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/QuxObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/QuxObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Shape.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Shape.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Square.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/Square.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/TestExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/TestExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016 Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/contextualReference/FooBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/contextualReference/FooBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/contextualReference/InvalidContextualReferenceTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/contextualReference/InvalidContextualReferenceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/customClassloader/Alpha.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/customClassloader/Alpha.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/customClassloader/AlphaExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/customClassloader/AlphaExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/customClassloader/Bravo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/customClassloader/Bravo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/customClassloader/BravoExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/customClassloader/BravoExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/customClassloader/CustomClassLoaderSETest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/customClassloader/CustomClassLoaderSETest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/customClassloader/MyExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/customClassloader/MyExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/customClassloader/ProcessedByExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/customClassloader/ProcessedByExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/testPackage/Apple.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/testPackage/Apple.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/testPackage/Worm.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/testPackage/Worm.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/testPackage/nestedPackage/Pear.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/testPackage/nestedPackage/Pear.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/ApplicationScopedCounter.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/ApplicationScopedCounter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/ApplicationScopedObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/ApplicationScopedObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/Baz.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/ContextSETest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/ContextSETest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/interceptor/ActivateRequestContextByInterceptorTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/interceptor/ActivateRequestContextByInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/interceptor/AfterActivationBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/interceptor/AfterActivationBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/interceptor/AfterActivationInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/interceptor/AfterActivationInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/interceptor/BeforeActivationBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/interceptor/BeforeActivationBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/interceptor/BeforeActivationInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/interceptor/BeforeActivationInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/interceptor/ClassInterceptorContextActivator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/interceptor/ClassInterceptorContextActivator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/interceptor/MethodInterceptorContextActivator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/interceptor/MethodInterceptorContextActivator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/interceptor/RequestContextObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/interceptor/RequestContextObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/interceptor/RequestScopeCounter.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/interceptor/RequestScopeCounter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/interceptor/SecondCounter.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/interceptor/SecondCounter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/programmatic/ActivateRequestContextProgrammaticallyTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/programmatic/ActivateRequestContextProgrammaticallyTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/programmatic/RequestScopeCounter.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/programmatic/RequestScopeCounter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/programmatic/TestContextActivator.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/activation/programmatic/TestContextActivator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/custom/AfterBeanDiscoveryObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/custom/AfterBeanDiscoveryObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/custom/CustomRequestContext.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/custom/CustomRequestContext.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/custom/CustomRequestContextSETest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/custom/CustomRequestContextSETest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/custom/RequestScopeCounter.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/custom/RequestScopeCounter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/custom/SecondCounter.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/custom/SecondCounter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/request/Payload.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/request/Payload.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/request/ReqScopedCounter.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/request/ReqScopedCounter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/request/RequestContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/request/RequestContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/request/TestBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/request/TestBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/request/TestObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/context/request/TestObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/customCDIProvider/CustomCDIProvider.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/customCDIProvider/CustomCDIProvider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/customCDIProvider/CustomCDIProviderTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/customCDIProvider/CustomCDIProviderTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/discovery/implicit/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/discovery/implicit/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/discovery/implicit/ImplicitBeanArchiveSETest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/discovery/implicit/ImplicitBeanArchiveSETest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/discovery/implicit/ImplicitBeanArchiveWithSystemPropertyTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/discovery/implicit/ImplicitBeanArchiveWithSystemPropertyTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/discovery/trimmed/Bar.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/discovery/trimmed/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/discovery/trimmed/BarInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/discovery/trimmed/BarInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/discovery/trimmed/BarInterceptorBinding.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/discovery/trimmed/BarInterceptorBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/discovery/trimmed/BarProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/discovery/trimmed/BarProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/discovery/trimmed/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/discovery/trimmed/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/discovery/trimmed/FooProducer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/discovery/trimmed/FooProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/discovery/trimmed/TestExtension.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/discovery/trimmed/TestExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/discovery/trimmed/TestStereotype.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/discovery/trimmed/TestStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/discovery/trimmed/TrimmedBeanArchiveSETest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/discovery/trimmed/TrimmedBeanArchiveSETest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/events/lifecycle/ObservingBean.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/events/lifecycle/ObservingBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2022, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/events/lifecycle/StartupShutdownTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/events/lifecycle/StartupShutdownTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2022, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/vetoed/Elephant.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/vetoed/Elephant.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/vetoed/Shark.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/vetoed/Shark.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/vetoed/VetoedTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/vetoed/VetoedTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/vetoed/aquarium/Fishy.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/vetoed/aquarium/Fishy.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/vetoed/aquarium/Piranha.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/vetoed/aquarium/Piranha.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/vetoed/aquarium/package-info.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/vetoed/aquarium/package-info.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat Middleware LLC, and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/util/ActionSequence.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/ActionSequence.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/util/AddForwardingAnnotatedTypeAction.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/AddForwardingAnnotatedTypeAction.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/util/Assert.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/Assert.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/util/BeanLookupUtils.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/BeanLookupUtils.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/util/DependentInstance.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/DependentInstance.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/util/ForwardingAnnotated.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/ForwardingAnnotated.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2008, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/util/ForwardingAnnotatedType.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/ForwardingAnnotatedType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2008, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/util/ForwardingBeanAttributes.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/ForwardingBeanAttributes.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/util/ForwardingInjectionPoint.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/ForwardingInjectionPoint.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/util/HierarchyDiscovery.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/HierarchyDiscovery.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/util/JndiLookupUtils.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/JndiLookupUtils.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/util/ParameterizedTypeImpl.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/ParameterizedTypeImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/util/SimpleLogger.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/SimpleLogger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/util/Timer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/Timer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/util/TransformationUtils.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/TransformationUtils.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/util/Versions.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/Versions.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/util/annotated/AnnotatedCallableWraper.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/annotated/AnnotatedCallableWraper.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/util/annotated/AnnotatedConstructorWrapper.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/annotated/AnnotatedConstructorWrapper.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/util/annotated/AnnotatedFieldWrapper.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/annotated/AnnotatedFieldWrapper.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/util/annotated/AnnotatedMemberWrapper.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/annotated/AnnotatedMemberWrapper.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/util/annotated/AnnotatedMethodWrapper.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/annotated/AnnotatedMethodWrapper.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/util/annotated/AnnotatedParameterWrapper.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/annotated/AnnotatedParameterWrapper.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/util/annotated/AnnotatedTypeWrapper.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/annotated/AnnotatedTypeWrapper.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/util/annotated/AnnotatedTypes.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/annotated/AnnotatedTypes.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/cdi/tck/util/annotated/AnnotatedWrapper.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/util/annotated/AnnotatedWrapper.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/shrinkwrap/api/BeanDiscoveryMode.java
+++ b/impl/src/main/java/org/jboss/shrinkwrap/api/BeanDiscoveryMode.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/shrinkwrap/api/BeansXmlVersion.java
+++ b/impl/src/main/java/org/jboss/shrinkwrap/api/BeansXmlVersion.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/main/java/org/jboss/shrinkwrap/impl/BeansXml.java
+++ b/impl/src/main/java/org/jboss/shrinkwrap/impl/BeansXml.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/test/java/org/jboss/cdi/tck/test/package-info.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/package-info.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/test/java/org/jboss/cdi/tck/test/porting/DummyBeans.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/porting/DummyBeans.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/test/java/org/jboss/cdi/tck/test/porting/DummyContexts.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/porting/DummyContexts.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/test/java/org/jboss/cdi/tck/test/porting/DummyContextuals.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/porting/DummyContextuals.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/test/java/org/jboss/cdi/tck/test/porting/DummyCreationalContexts.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/porting/DummyCreationalContexts.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/test/java/org/jboss/cdi/tck/test/porting/DummyEL.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/porting/DummyEL.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/AssetUtilTest.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/AssetUtilTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/Engine.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/Engine.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/EnginePowered.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/EnginePowered.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/Excluded.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/Excluded.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/PoweredEngine.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/PoweredEngine.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/Qux.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/Qux.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/TestClass.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/TestClass.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/WebArchiveBuilderTest.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/WebArchiveBuilderTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/beansxml/BeansXmlTest.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/beansxml/BeansXmlTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/beansxml/DummyReferenceClass.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/beansxml/DummyReferenceClass.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/descriptors/Bar.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/descriptors/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/descriptors/Foo.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/descriptors/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/test/java/org/jboss/cdi/tck/test/util/ActionSequenceTest.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/util/ActionSequenceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/test/java/org/jboss/cdi/tck/test/util/AssertTest.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/util/AssertTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/src/test/java/org/jboss/cdi/tck/test/util/TimerTest.java
+++ b/impl/src/test/java/org/jboss/cdi/tck/test/util/TimerTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/AnnotatedReceiverTypes.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/AnnotatedReceiverTypes.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/AnnotatedSuperTypes.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/AnnotatedSuperTypes.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/AnnotatedThrowsTypes.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/AnnotatedThrowsTypes.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/AnnotatedTypes.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/AnnotatedTypes.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/AnnotationInstances.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/AnnotationInstances.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/AnnotationMembers.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/AnnotationMembers.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/BridgeMethods.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/BridgeMethods.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/DefaultConstructors.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/DefaultConstructors.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/EnumMembers.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/EnumMembers.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/Equality.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/Equality.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/InheritedAnnotations.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/InheritedAnnotations.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/InheritedFields.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/InheritedFields.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/InheritedMethods.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/InheritedMethods.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/InterfaceMembers.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/InterfaceMembers.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/JavaLangObjectMethods.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/JavaLangObjectMethods.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/LangModelUtils.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/LangModelUtils.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/LangModelVerifier.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/LangModelVerifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/MissingAnnotation.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/MissingAnnotation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/PlainClassMembers.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/PlainClassMembers.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/PrimitiveTypes.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/PrimitiveTypes.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/RepeatableAnnotations.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/RepeatableAnnotations.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/SimpleAnnotation.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/SimpleAnnotation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/SimpleClass.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/SimpleClass.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/SimpleEnum.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/SimpleEnum.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/SimpleInterface.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/SimpleInterface.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/package-info.java
+++ b/lang-model/src/main/java/org/jboss/cdi/lang/model/tck/package-info.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ejb/AbstractInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ejb/AbstractInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ejb/AlphaBinding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ejb/AlphaBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ejb/AlphaInterceptor1.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ejb/AlphaInterceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ejb/AlphaInterceptor2.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ejb/AlphaInterceptor2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ejb/BeanOverridingTypeLevelBinding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ejb/BeanOverridingTypeLevelBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ejb/BeanWithConstructorLevelAndTypeLevelBinding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ejb/BeanWithConstructorLevelAndTypeLevelBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ejb/BeanWithConstructorLevelBinding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ejb/BeanWithConstructorLevelBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ejb/BeanWithTypeLevelBinding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ejb/BeanWithTypeLevelBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ejb/BravoBinding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ejb/BravoBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ejb/BravoInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ejb/BravoInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ejb/SessionBeanConstructorInterceptionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/aroundConstruct/ejb/SessionBeanConstructorInterceptionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/BallBinding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/BallBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/BallBindingLiteral.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/BallBindingLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/BasketBinding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/BasketBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/BasketBindingLiteral.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/BasketBindingLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/ComplicatedInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/ComplicatedInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/ComplicatedLifecycleInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/ComplicatedLifecycleInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/EnterpriseInterceptorBindingResolutionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/EnterpriseInterceptorBindingResolutionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/LoggedBinding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/LoggedBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/LoggedService.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/LoggedService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/MessageBinding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/MessageBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/MessageService.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/MessageService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/MonitorService.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/MonitorService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/PingBinding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/PingBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/PongBinding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/PongBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/RemoteMessageService.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/RemoteMessageService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/RemoteService.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/RemoteService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/Service.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/Service.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/ServiceStereotype.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/ServiceStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/TransactionalBinding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/bindings/resolution/ejb/TransactionalBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/ejb/Binding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/ejb/Binding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/ejb/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/ejb/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/ejb/Interceptor1.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/ejb/Interceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/ejb/Interceptor2.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/ejb/Interceptor2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/ejb/MiddleFoo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/ejb/MiddleFoo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/ejb/MiddleInterceptor1.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/ejb/MiddleInterceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/ejb/SessionBeanAroundInvokeInterceptorTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/ejb/SessionBeanAroundInvokeInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/ejb/SuperFoo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/ejb/SuperFoo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/ejb/SuperInterceptor1.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/ejb/SuperInterceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/ejb/SuperInterceptor2.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/bindings/ejb/SuperInterceptor2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ee/AroundInvokeAccessInterceptorTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ee/AroundInvokeAccessInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ee/Bar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ee/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ee/Baz.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ee/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ee/BazInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ee/BazInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ee/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ee/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ee/FooInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ee/FooInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ee/Printer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ee/Printer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ee/PrinterSecurityInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ee/PrinterSecurityInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ee/Student.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ee/Student.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ee/Toner.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundInvoke/ee/Toner.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/Alarm.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/Alarm.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/AlarmSecurityInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/AlarmSecurityInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/AroundTimeoutInterceptorTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/AroundTimeoutInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/Bell.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/Bell.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/Student.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/Student.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/TestData.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/TestData.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/TimeoutInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/TimeoutInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/TimingBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/TimingBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/bindings/AroundTimeoutOrderInterceptorTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/bindings/AroundTimeoutOrderInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/bindings/Binding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/bindings/Binding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/bindings/Interceptor1.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/bindings/Interceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/bindings/Interceptor2.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/bindings/Interceptor2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/bindings/MiddleInterceptor1.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/bindings/MiddleInterceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/bindings/MiddleTimingBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/bindings/MiddleTimingBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/bindings/SuperInterceptor1.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/bindings/SuperInterceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/bindings/SuperInterceptor2.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/bindings/SuperInterceptor2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/bindings/SuperTimingBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/bindings/SuperTimingBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/bindings/TimingBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/aroundTimeout/bindings/TimingBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/AroundInvokeInterceptor1.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/AroundInvokeInterceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/AroundInvokeInterceptor2.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/AroundInvokeInterceptor2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/AroundInvokeThreadInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/AroundInvokeThreadInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/AroundTimeoutThreadInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/AroundTimeoutThreadInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/Bar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/InterceptorEnvironmentTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/InterceptorEnvironmentTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/TestEndObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/TestEndObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/Animal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/Bar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/BarServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/BarServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/Cat.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/Cat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/Dog.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/Dog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/FooServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/FooServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/InterceptorEnvironmentJNDITest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/InterceptorEnvironmentJNDITest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/MyBinding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/MyBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/MyInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/MyInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/ejb/Animal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/ejb/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/ejb/Bar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/ejb/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/ejb/BarServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/ejb/BarServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/ejb/Cat.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/ejb/Cat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/ejb/Dog.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/ejb/Dog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/ejb/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/ejb/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/ejb/FooServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/ejb/FooServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/ejb/InterceptorEnvironmentJNDISessionBeanTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/ejb/InterceptorEnvironmentJNDISessionBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/ejb/MyBinding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/ejb/MyBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/ejb/MyInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/ejb/MyInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/ejb/Airborne.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/ejb/Airborne.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/ejb/AirborneInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/ejb/AirborneInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/ejb/DestructionInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/ejb/DestructionInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/ejb/Destructive.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/ejb/Destructive.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/ejb/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/ejb/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/ejb/Missile.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/ejb/Missile.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/ejb/Rocket.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/ejb/Rocket.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/ejb/SessionBeanLifecycleInterceptorDefinitionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/ejb/SessionBeanLifecycleInterceptorDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/ejb/SuperDestructionInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/ejb/SuperDestructionInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/ejb/Weapon.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/bindings/ejb/Weapon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/ejb/Animal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/ejb/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/ejb/AnimalInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/ejb/AnimalInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/ejb/Bar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/ejb/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/ejb/Cat.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/ejb/Cat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/ejb/CatInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/ejb/CatInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/ejb/LifecycleCallbackInterceptorTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/lifecycleCallback/ejb/LifecycleCallbackInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/jaxrs/JaxRsActivator.java
+++ b/web/src/main/java/org/jboss/cdi/tck/jaxrs/JaxRsActivator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/shrinkwrap/ee/DummySessionBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/shrinkwrap/ee/DummySessionBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/shrinkwrap/ee/EnterpriseArchiveBuilder.java
+++ b/web/src/main/java/org/jboss/cdi/tck/shrinkwrap/ee/EnterpriseArchiveBuilder.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/shrinkwrap/ee/WebArchiveBuilder.java
+++ b/web/src/main/java/org/jboss/cdi/tck/shrinkwrap/ee/WebArchiveBuilder.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/DisabledEjbInterface.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/DisabledEjbInterface.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/EjbInterface.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/EjbInterface.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/EnabledEjb.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/EnabledEjb.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/NotEnabledEjb.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/NotEnabledEjb.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/SessionBeanAlternativeTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/SessionBeanAlternativeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/resource/DatabaseProduction.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/resource/DatabaseProduction.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/resource/DatabaseTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/resource/DatabaseTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/resource/EnabledResourceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/resource/EnabledResourceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/resource/NotEnabledResourceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/resource/NotEnabledResourceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/resource/ResourceAlternativeAvailabilityTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/enterprise/resource/ResourceAlternativeAvailabilityTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/enterprise/EnterpriseSelectedAlternative01Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/enterprise/EnterpriseSelectedAlternative01Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/enterprise/EnterpriseSelectedAlternative02Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/enterprise/EnterpriseSelectedAlternative02Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/enterprise/EnterpriseSelectedAlternative03Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/enterprise/EnterpriseSelectedAlternative03Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/enterprise/EnterpriseService.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/enterprise/EnterpriseService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/enterprise/PojoService.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/enterprise/PojoService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/enterprise/SelectedAlternativeTestUtil.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/enterprise/SelectedAlternativeTestUtil.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/enterprise/Service.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/enterprise/Service.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/resource/BravoResourceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/resource/BravoResourceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/resource/CharlieResourceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/resource/CharlieResourceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/resource/DeltaResourceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/resource/DeltaResourceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/resource/ProductionReady.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/resource/ProductionReady.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/resource/ResourceAlternative01Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/resource/ResourceAlternative01Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/resource/ResourceAlternative04Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/resource/ResourceAlternative04Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/resource/ResourceAlternativeExplicitPriorityTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/resource/ResourceAlternativeExplicitPriorityTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/resource/ResourceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/alternative/selection/resource/ResourceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/activation/ActivateRequestContextinEETest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/activation/ActivateRequestContextinEETest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/activation/TestServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/activation/TestServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/ApplicationContextTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/ApplicationContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/ApplicationResource.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/ApplicationResource.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2008, Red Hat, Inc. and/or its affiliates, and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/IntrospectApplication.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/IntrospectApplication.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/Result.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/Result.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/SimpleApplicationBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/SimpleApplicationBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/TestFilter.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/TestFilter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/TestHttpSessionListener.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/TestHttpSessionListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/TestServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/TestServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/TestServletContextListener.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/TestServletContextListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/TestServletRequestListener.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/TestServletRequestListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/async/ApplicationContextAsyncListenerTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/async/ApplicationContextAsyncListenerTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/async/AsyncRequestProcessor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/async/AsyncRequestProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/async/AsyncServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/async/AsyncServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/async/FailingServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/async/FailingServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/async/SimpleApplicationBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/async/SimpleApplicationBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/async/SimpleAsyncListener.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/async/SimpleAsyncListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/async/StatusBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/async/StatusBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/async/StatusServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/async/StatusServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/destroy/ApplicationContextDestructionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/destroy/ApplicationContextDestructionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/destroy/Bar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/destroy/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/destroy/BarInfoServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/destroy/BarInfoServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/destroy/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/destroy/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/destroy/FooInitServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/destroy/FooInitServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/disposer/ApplicationContextDisposerTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/disposer/ApplicationContextDisposerTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/disposer/Edible.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/disposer/Edible.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/disposer/Forest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/disposer/Forest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/disposer/Mushroom.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/disposer/Mushroom.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/disposer/Mushroomer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/disposer/Mushroomer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/ejb/ApplicationContextSharedTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/ejb/ApplicationContextSharedTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/ejb/BarBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/ejb/BarBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/ejb/FMS.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/ejb/FMS.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/ejb/FMSModelIII.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/ejb/FMSModelIII.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/ejb/FooBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/ejb/FooBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/ejb/FooRemote.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/ejb/FooRemote.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/ejb/SimpleApplicationBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/ejb/SimpleApplicationBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/event/ApplicationScopeEventMultiWarTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/event/ApplicationScopeEventMultiWarTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/event/ApplicationScopeEventTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/event/ApplicationScopeEventTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/event/Collector.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/event/Collector.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/event/Helper.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/event/Helper.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/event/Observer1.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/event/Observer1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/event/Observer2.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/event/Observer2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/event/Observer3.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/event/Observer3.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/event/ObserverNames.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/event/ObserverNames.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/event/PingServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/event/PingServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/postconstruct/Action.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/postconstruct/Action.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/postconstruct/EagerSingleton.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/postconstruct/EagerSingleton.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/postconstruct/EagerSingletonPostConstructCallbackTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/postconstruct/EagerSingletonPostConstructCallbackTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/postconstruct/Service.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/postconstruct/Service.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/postconstruct/SimpleBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/postconstruct/SimpleBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/postconstruct/SimpleBeanPostConstructCallbackTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/postconstruct/SimpleBeanPostConstructCallbackTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/predestroy/ApplicationContextPreDestroyTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/predestroy/ApplicationContextPreDestroyTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/predestroy/Bar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/predestroy/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/application/predestroy/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/application/predestroy/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/AbstractConversationTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/AbstractConversationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/BuiltInConversation.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/BuiltInConversation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/ClientConversationContextTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/ClientConversationContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/Cloud.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/Cloud.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/CloudController.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/CloudController.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/ConversationContextObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/ConversationContextObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/ConversationStatusServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/ConversationStatusServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/ConversationTestPhaseListener.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/ConversationTestPhaseListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/Cumulus.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/Cumulus.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/InvalidatingSessionDestroysConversationTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/InvalidatingSessionDestroysConversationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/LongRunningConversationPropagatedByFacesContextTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/LongRunningConversationPropagatedByFacesContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/ManualCidPropagationTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/ManualCidPropagationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/OutermostFilter.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/OutermostFilter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/Storm.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/Storm.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/AsyncFooServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/AsyncFooServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/AsyncRequestProcessor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/AsyncRequestProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/BarFilter.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/BarFilter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/BazRequestListener.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/BazRequestListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/ConversationDeterminationTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/ConversationDeterminationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/Duck.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/Duck.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/FailingServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/FailingServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/FooServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/FooServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/QuxAsyncListener.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/QuxAsyncListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/StatusBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/StatusBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/StatusServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/StatusServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/TestResult.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/TestResult.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/event/ApplicationScopedObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/event/ApplicationScopedObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/event/ConversationScopedBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/event/ConversationScopedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/event/ConversationScopedObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/event/ConversationScopedObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/event/LongRunningConversationLifecycleEventTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/event/LongRunningConversationLifecycleEventTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/event/Servlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/event/Servlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/event/TransientConversationLifecycleEventTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/event/TransientConversationLifecycleEventTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/event/notattached/ConversationScopedBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/event/notattached/ConversationScopedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/event/notattached/DestroyConversationNotAssociatedWithCurrentRequestEventTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/event/notattached/DestroyConversationNotAssociatedWithCurrentRequestEventTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/event/notattached/ObservingBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/event/notattached/ObservingBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/event/notattached/TestServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/event/notattached/TestServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/filter/ConversationFilterTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/filter/ConversationFilterTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/filter/Dummy.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/filter/Dummy.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/filter/IntrospectServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/filter/IntrospectServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/filter/OuterFilter.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/filter/OuterFilter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/filter/State.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/filter/State.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/filter/Tester.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/filter/Tester.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/inactive/Bar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/inactive/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/inactive/FooBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/inactive/FooBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/inactive/InactiveConversationTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/inactive/InactiveConversationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/servlet/Message.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/servlet/Message.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/servlet/Servlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/servlet/Servlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/servlet/ServletConversationTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/conversation/servlet/ServletConversationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/DependentContextEjbTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/DependentContextEjbTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/Farm.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/Farm.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/FarmLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/FarmLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/Fox.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/Fox.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/FoxLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/FoxLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/FoxRun.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/FoxRun.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/FoxRunLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/FoxRunLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/Horse.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/Horse.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/House.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/House.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/HouseLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/HouseLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/Room.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/Room.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/RoomLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/RoomLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/Stable.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/Stable.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/Table.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/Table.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/TableLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/dependent/ejb/TableLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/jms/AbstractMessageListener.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/jms/AbstractMessageListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/jms/LogStore.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/jms/LogStore.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/jms/LoggerService.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/jms/LoggerService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/jms/MessageDrivenBeanContextTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/jms/MessageDrivenBeanContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/jms/QueueMessageDrivenBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/jms/QueueMessageDrivenBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/jms/SimpleMessageProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/jms/SimpleMessageProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/jms/TopicMessageDrivenBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/jms/TopicMessageDrivenBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/decorator/enterprise/EnterpriseBeanWithNonPassivatingDecoratorTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/decorator/enterprise/EnterpriseBeanWithNonPassivatingDecoratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/decorator/enterprise/MaarianHaminaLocal_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/decorator/enterprise/MaarianHaminaLocal_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/decorator/enterprise/MaarianhaminaDecorator.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/decorator/enterprise/MaarianhaminaDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/decorator/enterprise/Maarianhamina_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/decorator/enterprise/Maarianhamina_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/decorator/enterprise/field/BrokenDecorator.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/decorator/enterprise/field/BrokenDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/decorator/enterprise/field/District.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/decorator/enterprise/field/District.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/decorator/enterprise/field/EnterpriseBeanWithNonPassivatingInjectedFieldInDecoratorTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/decorator/enterprise/field/EnterpriseBeanWithNonPassivatingInjectedFieldInDecoratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/decorator/enterprise/field/EspooLocal_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/decorator/enterprise/field/EspooLocal_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/decorator/enterprise/field/Espoo_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/decorator/enterprise/field/Espoo_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/enterprise/Cup_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/enterprise/Cup_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/enterprise/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/enterprise/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/enterprise/NonPassivationCapableEjbWithPassivatingScopeTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/enterprise/NonPassivationCapableEjbWithPassivatingScopeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/enterprise/field/District.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/enterprise/field/District.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/enterprise/field/EspooLocal_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/enterprise/field/EspooLocal_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/enterprise/field/Espoo_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/enterprise/field/Espoo_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/enterprise/field/UnserializableSimpleInjectedIntoPassivatingEnterpriseBeanTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/enterprise/field/UnserializableSimpleInjectedIntoPassivatingEnterpriseBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/interceptor/enterprise/Digital.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/interceptor/enterprise/Digital.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/interceptor/enterprise/DigitalInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/interceptor/enterprise/DigitalInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/interceptor/enterprise/EnterpriseBeanWithNonPassivatingInterceptorTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/interceptor/enterprise/EnterpriseBeanWithNonPassivatingInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/interceptor/enterprise/Telephone.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/interceptor/enterprise/Telephone.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/interceptor/enterprise/field/BrokenInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/interceptor/enterprise/field/BrokenInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/interceptor/enterprise/field/District.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/interceptor/enterprise/field/District.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/interceptor/enterprise/field/EnterpriseBeanWithNonPassivatingInjectedFieldInInterceptorTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/interceptor/enterprise/field/EnterpriseBeanWithNonPassivatingInjectedFieldInInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/interceptor/enterprise/field/EspooLocal_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/interceptor/enterprise/field/EspooLocal_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/interceptor/enterprise/field/Espoo_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/interceptor/enterprise/field/Espoo_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/field/enterprise/British.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/field/enterprise/British.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/field/enterprise/ConstructorInjectionCorralBroken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/field/enterprise/ConstructorInjectionCorralBroken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/field/enterprise/Corral.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/field/enterprise/Corral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/field/enterprise/Cow.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/field/enterprise/Cow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/field/enterprise/CowProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/field/enterprise/CowProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/field/enterprise/EnterpriseBeanWithIllegalDependencyTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/field/enterprise/EnterpriseBeanWithIllegalDependencyTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/field/enterprise/FieldInjectionCorralBroken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/field/enterprise/FieldInjectionCorralBroken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/field/enterprise/SetterInjectionCorralBroken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/field/enterprise/SetterInjectionCorralBroken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/method/enterprise/British.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/method/enterprise/British.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/method/enterprise/ConstructorInjectionCorralBroken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/method/enterprise/ConstructorInjectionCorralBroken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/method/enterprise/Cow.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/method/enterprise/Cow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/method/enterprise/CowProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/method/enterprise/CowProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/method/enterprise/EnterpriseBeanWithIllegalDependencyTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/method/enterprise/EnterpriseBeanWithIllegalDependencyTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/method/enterprise/FieldInjectionCorralBroken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/method/enterprise/FieldInjectionCorralBroken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/method/enterprise/Herd.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/method/enterprise/Herd.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/method/enterprise/ProducerMethodParamInjectionCorralBroken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/method/enterprise/ProducerMethodParamInjectionCorralBroken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/method/enterprise/Ranch.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/method/enterprise/Ranch.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/method/enterprise/SetterInjectionCorralBroken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/broken/producer/method/enterprise/SetterInjectionCorralBroken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/resource/persistence/Another.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/resource/persistence/Another.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/resource/persistence/DataSourcePassivationDependencyTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/resource/persistence/DataSourcePassivationDependencyTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/resource/persistence/DataSourceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/resource/persistence/DataSourceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/resource/persistence/Pool.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/resource/persistence/Pool.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/resource/persistence/Profile.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/resource/persistence/Profile.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/resource/persistence/ResourcePassivationDependencyTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/resource/persistence/ResourcePassivationDependencyTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/resource/persistence/ResourceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/resource/persistence/ResourceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/resource/remote/ResourcePassivationDependencyTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/resource/remote/ResourcePassivationDependencyTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/resource/remote/Worker.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/resource/remote/Worker.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/resource/remote/ejb/FooBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/resource/remote/ejb/FooBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/resource/remote/ejb/FooRemote.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/resource/remote/ejb/FooRemote.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/sessionbean/Chef.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/sessionbean/Chef.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/sessionbean/Hammer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/sessionbean/Hammer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/sessionbean/SessionBeanPassivationDependencyTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/sessionbean/SessionBeanPassivationDependencyTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/sessionbean/Spoon.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/sessionbean/Spoon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/sessionbean/Worker.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/dependency/sessionbean/Worker.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/Digital.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/Digital.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/DigitalInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/DigitalInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/NonPassivationCapableSessionBeanTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/NonPassivationCapableSessionBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/Telephone.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/Telephone.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/TelephoneLine.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/TelephoneLine.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/invalid/Digital.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/invalid/Digital.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/invalid/DigitalInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/invalid/DigitalInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/invalid/Elephant.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/invalid/Elephant.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/invalid/ElephantLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/invalid/ElephantLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/invalid/StatefulSessionBeanTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/invalid/StatefulSessionBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/invalid/StatefulSessionBeanXmlDescriptorTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/invalid/StatefulSessionBeanXmlDescriptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/invalid/Telephone.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/invalid/Telephone.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/invalid/TelephoneLine.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/invalid/TelephoneLine.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/valid/Digital.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/valid/Digital.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/valid/DigitalInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/valid/DigitalInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/valid/Elephant.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/valid/Elephant.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/valid/ElephantLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/valid/ElephantLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/valid/StatefulSessionBeanTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/valid/StatefulSessionBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/valid/StatefulSessionBeanXmlDescriptorTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/valid/StatefulSessionBeanXmlDescriptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/valid/Telephone.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/valid/Telephone.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/valid/TelephoneLine.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/passivating/enterprise/valid/TelephoneLine.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/ContextDestructionObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/ContextDestructionObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/IntrospectFilter.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/IntrospectFilter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/IntrospectServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/IntrospectServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/RequestContextTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/RequestContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/SimpleRequestBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/SimpleRequestBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/TestFilter.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/TestFilter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/TestServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/TestServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/TestServletRequestListener.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/TestServletRequestListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/async/AsyncRequestProcessor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/async/AsyncRequestProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/async/AsyncServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/async/AsyncServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/async/FailingServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/async/FailingServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/async/RequestContextAsyncListenerTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/async/RequestContextAsyncListenerTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/async/SimpleAsyncListener.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/async/SimpleAsyncListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/async/SimpleRequestBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/async/SimpleRequestBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/async/StatusBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/async/StatusBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/async/StatusServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/async/StatusServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/ejb/BarBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/ejb/BarBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/ejb/EJBRequestContextTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/ejb/EJBRequestContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/ejb/FMS.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/ejb/FMS.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/ejb/FMSModelIII.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/ejb/FMSModelIII.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/ejb/FooBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/ejb/FooBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/ejb/FooRemote.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/ejb/FooRemote.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/ejb/FooRequestBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/ejb/FooRequestBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/ejb/SimpleRequestBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/ejb/SimpleRequestBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/ObservingBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/ObservingBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/RequestScopeEventTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/RequestScopeEventTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/Servlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/Servlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/async/ApplicationScopedObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/async/ApplicationScopedObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/async/AsyncService.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/async/AsyncService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/async/InfoServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/async/InfoServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/async/RequestScopeEventAsyncTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/async/RequestScopeEventAsyncTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/async/RequestScopedObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/async/RequestScopedObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/jms/AbstractMessageListener.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/jms/AbstractMessageListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/jms/ApplicationScopedObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/jms/ApplicationScopedObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/jms/RequestScopeEventMessageDeliveryTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/jms/RequestScopeEventMessageDeliveryTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/jms/RequestScopedObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/jms/RequestScopedObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/jms/SimpleMessageProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/jms/SimpleMessageProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/jms/TopicMessageDrivenBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/jms/TopicMessageDrivenBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/remote/ApplicationScopedObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/remote/ApplicationScopedObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/remote/FooBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/remote/FooBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/remote/FooRemote.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/remote/FooRemote.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/remote/RequestScopeEventRemoteTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/remote/RequestScopeEventRemoteTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/remote/RequestScopedObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/remote/RequestScopedObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/timeout/ApplicationScopedObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/timeout/ApplicationScopedObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/timeout/InfoServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/timeout/InfoServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/timeout/RequestScopeEventTimeoutTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/timeout/RequestScopeEventTimeoutTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/timeout/RequestScopedObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/timeout/RequestScopedObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/timeout/TimeoutService.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/event/timeout/TimeoutService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/jaxrs/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/jaxrs/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2008, Red Hat, Inc. and/or its affiliates, and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/jaxrs/FooResource.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/jaxrs/FooResource.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2008, Red Hat, Inc. and/or its affiliates, and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/jaxrs/InfoServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/jaxrs/InfoServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/jaxrs/ObservingBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/jaxrs/ObservingBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/jaxrs/RequestContextTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/jaxrs/RequestContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/postconstruct/Action.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/postconstruct/Action.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/postconstruct/EagerSingleton.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/postconstruct/EagerSingleton.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/postconstruct/EagerSingletonInfoServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/postconstruct/EagerSingletonInfoServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/postconstruct/EagerSingletonPostConstructCallbackTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/postconstruct/EagerSingletonPostConstructCallbackTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/postconstruct/RequestContextObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/postconstruct/RequestContextObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/postconstruct/SimpleBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/postconstruct/SimpleBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/postconstruct/SimpleBeanPostConstructCallbackTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/postconstruct/SimpleBeanPostConstructCallbackTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/request/postconstruct/SimpleInfoServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/request/postconstruct/SimpleInfoServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/IntrospectFilter.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/IntrospectFilter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/IntrospectHttpSessionListener.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/IntrospectHttpSessionListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/IntrospectServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/IntrospectServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/IntrospectServletRequestListener.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/IntrospectServletRequestListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/SessionContextTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/SessionContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/SimpleSessionBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/SimpleSessionBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/TestFilter.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/TestFilter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/TestServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/TestServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/async/AsyncRequestProcessor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/async/AsyncRequestProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/async/AsyncServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/async/AsyncServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/async/FailingServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/async/FailingServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/async/SessionContextAsyncListenerTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/async/SessionContextAsyncListenerTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/async/SimpleAsyncListener.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/async/SimpleAsyncListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/async/SimpleSessionBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/async/SimpleSessionBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/async/StatusBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/async/StatusBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/async/StatusServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/async/StatusServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/event/ObservingBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/event/ObservingBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/event/Servlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/event/Servlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/event/SessionScopeEventTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/event/SessionScopeEventTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/event/SessionScopedBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/event/SessionScopedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/IntrospectServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/IntrospectServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/SessionContextHttpSessionListenerTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/SessionContextHttpSessionListenerTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/SessionContextServletRequestListenerTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/SessionContextServletRequestListenerTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/SimpleSessionBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/SimpleSessionBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/TestHttpSessionListener.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/TestHttpSessionListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/TestServletRequestListener.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/TestServletRequestListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/shutdown/InfoServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/shutdown/InfoServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/shutdown/InitServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/shutdown/InitServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/shutdown/SessionContextListenerShutdownTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/shutdown/SessionContextListenerShutdownTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/shutdown/SessionScopedTestFlagClient.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/shutdown/SessionScopedTestFlagClient.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/shutdown/TestFlag.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/shutdown/TestFlag.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/shutdown/TestHttpSessionListener.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/shutdown/TestHttpSessionListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/request/BuiltinHttpServletRequestDecoratorTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/request/BuiltinHttpServletRequestDecoratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/request/HttpServletRequestDecorator1.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/request/HttpServletRequestDecorator1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/request/HttpServletRequestDecorator2.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/request/HttpServletRequestDecorator2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/servletcontext/BuiltinServletContextDecoratorTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/servletcontext/BuiltinServletContextDecoratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/servletcontext/ServletContextDecorator1.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/servletcontext/ServletContextDecorator1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/servletcontext/ServletContextDecorator2.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/servletcontext/ServletContextDecorator2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/session/BuiltinHttpSessionDecoratorTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/session/BuiltinHttpSessionDecoratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/session/HttpSessionDecorator1.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/session/HttpSessionDecorator1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/session/HttpSessionDecorator2.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/session/HttpSessionDecorator2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/session/HttpSessionObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/session/HttpSessionObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/session/SessionListener.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/http/session/SessionListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/principal/BuiltinPrincipalDecoratorTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/principal/BuiltinPrincipalDecoratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/principal/PrincipalDecorator.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/principal/PrincipalDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/principal/PrincipalInjector.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/principal/PrincipalInjector.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/transaction/BuiltinUserTransactionDecoratorTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/transaction/BuiltinUserTransactionDecoratorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/transaction/SessionBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/transaction/SessionBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/transaction/UserTransactionDecorator.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/builtin/transaction/UserTransactionDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/lifecycle/BankAccount.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/lifecycle/BankAccount.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/lifecycle/BankServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/lifecycle/BankServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/lifecycle/ChargeDecorator.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/lifecycle/ChargeDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/lifecycle/DecoratorInstanceIsDependentObjectTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/lifecycle/DecoratorInstanceIsDependentObjectTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/lifecycle/DurableAccount.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/lifecycle/DurableAccount.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/lifecycle/ShortTermAccount.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/lifecycle/ShortTermAccount.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/ejb/EJBDecoratorInvocationTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/ejb/EJBDecoratorInvocationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/ejb/Pig.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/ejb/Pig.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/ejb/PigSty.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/ejb/PigSty.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/ejb/PigStyDecorator.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/ejb/PigStyDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/ejb/PigStyImpl.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/ejb/PigStyImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/enterprise/Bar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/enterprise/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/enterprise/BarBusiness.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/enterprise/BarBusiness.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/enterprise/BarBusinessDecorator.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/enterprise/BarBusinessDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/enterprise/Business.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/enterprise/Business.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/enterprise/BusinessBase.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/enterprise/BusinessBase.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/enterprise/EnterpriseDecoratorInvocationTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/enterprise/EnterpriseDecoratorInvocationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/enterprise/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/enterprise/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/enterprise/FooBinding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/enterprise/FooBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/enterprise/FooBusiness.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/enterprise/FooBusiness.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/enterprise/FooBusinessDecorator1.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/enterprise/FooBusinessDecorator1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/enterprise/FooBusinessDecorator2.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/enterprise/FooBusinessDecorator2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/enterprise/FooInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/invocation/enterprise/FooInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/AbstractDecorator.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/AbstractDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/Decorated.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/Decorated.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/DecoratedImpl.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/DecoratedImpl.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/DummyDao.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/DummyDao.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/EnterpriseDecoratorOrderingTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/EnterpriseDecoratorOrderingTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/GlobalDecoratorOrderingTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/GlobalDecoratorOrderingTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/GloballyEnabledDecorator1.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/GloballyEnabledDecorator1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/GloballyEnabledDecorator2.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/GloballyEnabledDecorator2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/GloballyEnabledDecorator3.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/GloballyEnabledDecorator3.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/GloballyEnabledDecorator4.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/GloballyEnabledDecorator4.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/GloballyEnabledDecorator5.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/GloballyEnabledDecorator5.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/LegacyDecorator1.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/LegacyDecorator1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/LegacyDecorator2.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/LegacyDecorator2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/LegacyDecorator3.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/LegacyDecorator3.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/WebApplicationGlobalDecorator.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/decorators/ordering/global/WebApplicationGlobalDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/ejb/RestrictedSessionBeanTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/ejb/RestrictedSessionBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2011, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/ejb/RockBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/broken/restricted/ejb/RockBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2011, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/Animal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/Bird.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/Bird.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/Cobra.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/Cobra.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/Creature.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/Creature.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/CreatureLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/CreatureLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/LegendaryCreature.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/LegendaryCreature.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/LegendaryLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/LegendaryLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/LoginAction.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/LoginAction.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/LoginActionBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/LoginActionBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/Mammal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/Mammal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/Mock.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/Mock.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/MockLoginActionBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/MockLoginActionBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/Reptile.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/Reptile.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/SessionBeanTypesTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/SessionBeanTypesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/Snake.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/Snake.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/Tiger.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/Tiger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/Vulture.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/Vulture.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/illegal/Animal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/illegal/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/illegal/AnimalHolder.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/illegal/AnimalHolder.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/illegal/BeanTypesWithIllegalTypeTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/illegal/BeanTypesWithIllegalTypeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/illegal/Bird.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/illegal/Bird.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/illegal/Eagle.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/illegal/Eagle.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/illegal/Produced.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/illegal/Produced.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/BorderCollie.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/BorderCollie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/BorderCollieLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/BorderCollieLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/EnglishBorderCollie.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/EnglishBorderCollie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/EnglishBorderCollieLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/EnglishBorderCollieLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/EnterpriseQualifierDefinitionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/EnterpriseQualifierDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/FamousCat.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/FamousCat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/FamousCatLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/FamousCatLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/Hairless.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/Hairless.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/HairlessCat.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/HairlessCat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/HairlessQualifier.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/HairlessQualifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/Hairy.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/Hairy.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/HairyQualifier.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/HairyQualifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/LongHairedDog.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/LongHairedDog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/Skinny.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/Skinny.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/SkinnyHairlessCat.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/SkinnyHairlessCat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/SkinnyHairlessCatLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/SkinnyHairlessCatLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/SkinnyQualifier.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/SkinnyQualifier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/TameSkinnyHairlessCat.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/TameSkinnyHairlessCat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/TameSkinnyHairlessCatLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/TameSkinnyHairlessCatLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/ejb/SessionBeanTooManyScopesTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/ejb/SessionBeanTooManyScopesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/ejb/SessionBeanWithTooManyScopeTypes_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/ejb/SessionBeanWithTooManyScopeTypes_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/ejb/producer/field/SessionBeanProducerFieldTooManyScopesTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/ejb/producer/field/SessionBeanProducerFieldTooManyScopesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/ejb/producer/field/SessionBeanProducerFieldWithTooManyScopeTypes_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/ejb/producer/field/SessionBeanProducerFieldWithTooManyScopeTypes_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/ejb/producer/field/Word.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/ejb/producer/field/Word.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/ejb/producer/method/SessionBeanProducerMethodTooManyScopesTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/ejb/producer/method/SessionBeanProducerMethodTooManyScopesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/ejb/producer/method/SessionBeanProducerMethodWithTooManyScopeTypes_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/ejb/producer/method/SessionBeanProducerMethodWithTooManyScopeTypes_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/ejb/producer/method/Word.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/broken/tooManyScopes/ejb/producer/method/Word.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/enterprise/BengalTiger.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/enterprise/BengalTiger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/enterprise/BengalTigerLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/enterprise/BengalTigerLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/enterprise/BorderCollie.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/enterprise/BorderCollie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/enterprise/BorderCollieLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/enterprise/BorderCollieLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/enterprise/Cat.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/enterprise/Cat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/enterprise/Dog.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/enterprise/Dog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/enterprise/EnglishBorderCollie.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/enterprise/EnglishBorderCollie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/enterprise/EnglishBorderCollieLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/enterprise/EnglishBorderCollieLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/enterprise/EnterpriseScopeDefinitionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/enterprise/EnterpriseScopeDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/enterprise/FooScoped.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/enterprise/FooScoped.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/enterprise/Siamese.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/enterprise/Siamese.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/enterprise/SiameseLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/enterprise/SiameseLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/enterprise/Tiger.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/scope/enterprise/Tiger.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/alternative/enterprise/AbstractService.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/alternative/enterprise/AbstractService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/alternative/enterprise/EnterpriseStereotypeAlternativeSpecializeTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/alternative/enterprise/EnterpriseStereotypeAlternativeSpecializeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/alternative/enterprise/EnterpriseStereotypeAlternativeTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/alternative/enterprise/EnterpriseStereotypeAlternativeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/alternative/enterprise/Mock.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/alternative/enterprise/Mock.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/alternative/enterprise/MockService.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/alternative/enterprise/MockService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/alternative/enterprise/RealService.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/alternative/enterprise/RealService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/alternative/enterprise/Service.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/alternative/enterprise/Service.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/alternative/enterprise/SimpleAlternativeService.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/alternative/enterprise/SimpleAlternativeService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/Animal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/AnimalStereotype.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/AnimalStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/Barracuda.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/Barracuda.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/BarracudaLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/BarracudaLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/BorderCollie.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/BorderCollie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/BorderCollieLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/BorderCollieLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/Chihuahua.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/Chihuahua.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/ChihuahuaLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/ChihuahuaLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/EnglishBorderCollie.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/EnglishBorderCollie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/EnglishBorderCollieLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/EnglishBorderCollieLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/EnterpriseStereotypeDefinitionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/EnterpriseStereotypeDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/Fish.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/Fish.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/FishStereotype.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/FishStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/LongHairedDog.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/LongHairedDog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/MexicanChihuahua.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/MexicanChihuahua.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/MexicanChihuahuaLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/MexicanChihuahuaLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/ShortHairedDog.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/ShortHairedDog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/TameBarracuda.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/TameBarracuda.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/TameBarracudaLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/enterprise/TameBarracudaLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/enterprise/AlphaBinding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/enterprise/AlphaBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/enterprise/AlphaInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/enterprise/AlphaInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/enterprise/AlphaStereotype.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/enterprise/AlphaStereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/enterprise/EnterpriseStereotypeInterceptorBindingTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/enterprise/EnterpriseStereotypeInterceptorBindingTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/enterprise/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/definition/stereotype/interceptor/enterprise/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/Alpha.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/Alpha.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/AlphaLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/AlphaLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/Bravo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/Bravo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/BravoLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/BravoLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/Charlie.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/Charlie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/CharlieLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/CharlieLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/Delta.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/Delta.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/DeltaLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/DeltaLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/Echo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/Echo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/EchoLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/EchoLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/EnterpriseBeanDiscoveryTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/EnterpriseBeanDiscoveryTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/Foxtrot.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/Foxtrot.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/FoxtrotLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/FoxtrotLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/LegacyBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/LegacyBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/LegacyExtension.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/LegacyExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/Ping.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/Ping.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/VerifyingExtension.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/VerifyingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/annotated/Apple.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/annotated/Apple.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/annotated/AppleTree.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/annotated/AppleTree.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/annotated/AppleTreeLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/annotated/AppleTreeLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/annotated/EnterpriseDefaultBeanDiscoveryModeTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/annotated/EnterpriseDefaultBeanDiscoveryModeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/annotated/TestExtension.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/enterprise/annotated/TestExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/implicit/DefaultBeanDiscoveryModeTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/implicit/DefaultBeanDiscoveryModeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/implicit/DummyBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/implicit/DummyBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2018, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/implicit/NotDiscoveredBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/implicit/NotDiscoveredBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/implicit/ProducedBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/implicit/ProducedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/implicit/TestExtension.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/discovery/implicit/TestExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/bundledLibrary/Bar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/bundledLibrary/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/bundledLibrary/Baz.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/bundledLibrary/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/bundledLibrary/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/bundledLibrary/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/bundledLibrary/LibraryInEarTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/bundledLibrary/LibraryInEarTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/bundledLibrary/LibraryInWarTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/bundledLibrary/LibraryInWarTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/bundledLibrary/LibraryMissingBeansXmlTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/bundledLibrary/LibraryMissingBeansXmlTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/bundledLibrary/Unlucky.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/bundledLibrary/Unlucky.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/BarBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/BarBean.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/BarExtension.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/BarExtension.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/BarWebBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/BarWebBean.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/FooBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/FooBean.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/FooExtension.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/FooExtension.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/FooWebBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/FooWebBean.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/MultiWebModuleWithExtensionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/MultiWebModuleWithExtensionTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/SingleWebModuleWithExtensionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/SingleWebModuleWithExtensionTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/AlternativeBar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/AlternativeBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/Bar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/BarInspector.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/BarInspector.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/Baz.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/Business.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/Business.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/BusinessOperationEvent.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/BusinessOperationEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/BusinessOperationEventInspector.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/BusinessOperationEventInspector.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/BusinessOperationObservedEvent.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/BusinessOperationObservedEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/ContainerEventsObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/ContainerEventsObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/EnterpriseArchiveModulesTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/EnterpriseArchiveModulesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/LegacyService.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/LegacyService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/LegacyServiceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/LegacyServiceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/LoggingDecorator.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/LoggingDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/NonEnterprise.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/NonEnterprise.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/Qux.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/Qux.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/Secured.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/Secured.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/SecurityInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/SecurityInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/Util.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ear/modules/Util.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ejb/Bar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ejb/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ejb/EJBJarDeploymentTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ejb/EJBJarDeploymentTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ejb/FooBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ejb/FooBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ejb/FooRemote.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ejb/FooRemote.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ejb/ProcessBeanObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/ejb/ProcessBeanObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/installedLibrary/Alpha.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/installedLibrary/Alpha.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/installedLibrary/AssertBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/installedLibrary/AssertBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/installedLibrary/Bravo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/installedLibrary/Bravo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/installedLibrary/Charlie.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/installedLibrary/Charlie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/installedLibrary/InstalledLibraryEarTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/installedLibrary/InstalledLibraryEarTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/installedLibrary/InstalledLibraryWarTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/installedLibrary/InstalledLibraryWarTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/rar/ResourceAdapterArchiveTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/rar/ResourceAdapterArchiveTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/rar/TestResourceAdapter.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/rar/TestResourceAdapter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/rar/Translator.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/rar/Translator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/visibility/American.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/visibility/American.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/visibility/AnnotatedTypeObserverExtension.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/visibility/AnnotatedTypeObserverExtension.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/visibility/Bar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/visibility/Bar.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/visibility/Beer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/visibility/Beer.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/visibility/BeerCollector.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/visibility/BeerCollector.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/visibility/CraftBeer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/visibility/CraftBeer.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/visibility/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/visibility/Foo.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/visibility/JarToJarAlphaVisibilityTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/visibility/JarToJarAlphaVisibilityTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/visibility/JarToJarReverseAlphaVisibilityTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/visibility/JarToJarReverseAlphaVisibilityTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/visibility/Soda.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/visibility/Soda.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/visibility/VisibilityOfAnnotatedTypesFromExtensionInAlphaBeanArchiveTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/visibility/VisibilityOfAnnotatedTypesFromExtensionInAlphaBeanArchiveTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/visibility/VisibilityOfAnnotatedTypesFromExtensionInBravoBeanArchiveTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/visibility/VisibilityOfAnnotatedTypesFromExtensionInBravoBeanArchiveTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/visibility/VisibilityOfBeanInWebModuleFromBeanManagerInBeanLibraryTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/visibility/VisibilityOfBeanInWebModuleFromBeanManagerInBeanLibraryTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/BeansDescriptorAlternativeLocationTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/BeansDescriptorAlternativeLocationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/AlternativeBar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/AlternativeBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/Bar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/BarInspector.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/BarInspector.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/Baz.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/Bazinga.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/Bazinga.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/Business.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/Business.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/BusinessOperationEvent.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/BusinessOperationEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/ContainerEventsObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/ContainerEventsObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/LegacyService.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/LegacyService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/LegacyServiceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/LegacyServiceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/LoggingDecorator.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/LoggingDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/Qux.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/Qux.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/Secured.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/Secured.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/SecurityInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/SecurityInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/WebArchiveModulesTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/war/modules/WebArchiveModulesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/shutdown/ApplicationShutdownLifecycleTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/shutdown/ApplicationShutdownLifecycleTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/shutdown/Bar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/shutdown/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/shutdown/Baz.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/shutdown/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/shutdown/ContextDestructionObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/shutdown/ContextDestructionObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/shutdown/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/shutdown/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/shutdown/InfoClient.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/shutdown/InfoClient.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/shutdown/InfoServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/shutdown/InfoServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/shutdown/InitServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/shutdown/InitServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/shutdown/LifecycleMonitoringExtension.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/shutdown/LifecycleMonitoringExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/shutdown/Qux.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/shutdown/Qux.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/trimmed/enteprise/Bike.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/trimmed/enteprise/Bike.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/trimmed/enteprise/Car.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/trimmed/enteprise/Car.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/trimmed/enteprise/EnterpriseTrimmedBeanArchiveTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/trimmed/enteprise/EnterpriseTrimmedBeanArchiveTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/trimmed/enteprise/MotorizedVehicle.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/trimmed/enteprise/MotorizedVehicle.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/deployment/trimmed/enteprise/TestExtension.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/deployment/trimmed/enteprise/TestExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/notBusinessMethod/EJBObserverMethodNotBusinessMethodTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/notBusinessMethod/EJBObserverMethodNotBusinessMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/notBusinessMethod/Terrier.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/notBusinessMethod/Terrier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/notBusinessMethod/TibetanTerrier_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/notBusinessMethod/TibetanTerrier_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/remoteBusinessMethod/EJBAsyncObserverMethodRemoteBusinessMethodTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/remoteBusinessMethod/EJBAsyncObserverMethodRemoteBusinessMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/remoteBusinessMethod/EJBObserverMethodRemoteBusinessMethodTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/remoteBusinessMethod/EJBObserverMethodRemoteBusinessMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/remoteBusinessMethod/FoxTerrrier.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/remoteBusinessMethod/FoxTerrrier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/remoteBusinessMethod/Terrier.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/remoteBusinessMethod/Terrier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/remoteBusinessMethod/TibetanTerrier.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/broken/observer/remoteBusinessMethod/TibetanTerrier.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/FooObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/FooObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/ObserverMethodInvocationContextTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/ObserverMethodInvocationContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/Printer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/Printer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/Student.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/Student.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/Toner.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/Toner.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/async/AsyncMessageObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/async/AsyncMessageObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/async/AsyncObserverMethodInvocationContextTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/async/AsyncObserverMethodInvocationContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/async/Counter.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/async/Counter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/async/Message.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/async/Message.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/async/enterprise/EnterpriseSecurityContextPropagationInAsyncObserverTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/async/enterprise/EnterpriseSecurityContextPropagationInAsyncObserverTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/async/enterprise/Printer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/async/enterprise/Printer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/async/enterprise/Student.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/async/enterprise/Student.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/async/enterprise/Teacher.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/async/enterprise/Teacher.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/async/enterprise/Text.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/async/enterprise/Text.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/FooObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/FooObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/ObserverLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/ObserverLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/Printer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/Printer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/SessionBeanObserverMethodInvocationContextTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/SessionBeanObserverMethodInvocationContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/Student.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/Student.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/Toner.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/Toner.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/staticMethod/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/staticMethod/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/staticMethod/FooObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/staticMethod/FooObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/staticMethod/Printer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/staticMethod/Printer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/staticMethod/SessionBeanStaticObserverMethodInvocationContextTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/staticMethod/SessionBeanStaticObserverMethodInvocationContextTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/staticMethod/Student.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/staticMethod/Student.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/staticMethod/Toner.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/staticMethod/Toner.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/enterprise/Egg.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/enterprise/Egg.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/enterprise/EnterpriseObserverInheritanceTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/enterprise/EnterpriseObserverInheritanceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/enterprise/EventPayload.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/enterprise/EventPayload.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/enterprise/Farmer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/enterprise/Farmer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/enterprise/FarmerLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/enterprise/FarmerLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/enterprise/IndirectStockWatcher.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/enterprise/IndirectStockWatcher.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/enterprise/IndirectStockWatcherLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/enterprise/IndirectStockWatcherLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/enterprise/IntermediateStockWatcher.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/enterprise/IntermediateStockWatcher.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/enterprise/LazyFarmer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/enterprise/LazyFarmer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/enterprise/LazyFarmerLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/enterprise/LazyFarmerLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/enterprise/StockPrice.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/enterprise/StockPrice.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/enterprise/StockWatcher.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/enterprise/StockWatcher.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/enterprise/StockWatcherLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/inheritance/enterprise/StockWatcherLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/contextLifecycleEvent/ee/InfoServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/contextLifecycleEvent/ee/InfoServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/contextLifecycleEvent/ee/RequestContextLifecycleEventObserverOrderingTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/contextLifecycleEvent/ee/RequestContextLifecycleEventObserverOrderingTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/contextLifecycleEvent/ee/RequestContextLifecycleObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/contextLifecycleEvent/ee/RequestContextLifecycleObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/transactional/AbstractObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/transactional/AbstractObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/transactional/OnlineAccountService.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/transactional/OnlineAccountService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/transactional/PhisherAccountTransactionObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/transactional/PhisherAccountTransactionObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/transactional/ReceiverAccountTransactionObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/transactional/ReceiverAccountTransactionObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/transactional/SenderAccountTransactionObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/transactional/SenderAccountTransactionObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/transactional/TransactionalPriorityObserverTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/transactional/TransactionalPriorityObserverTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/transactional/TxFailure.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/transactional/TxFailure.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/transactional/TxWithdrawal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/transactional/TxWithdrawal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/enterprise/EJBEvent.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/enterprise/EJBEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/enterprise/LocalInterface.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/enterprise/LocalInterface.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/enterprise/NoInterfaceSLSB.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/enterprise/NoInterfaceSLSB.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/enterprise/ResolveEnterpriseEventObserverTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/enterprise/ResolveEnterpriseEventObserverTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/enterprise/Spitz.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/resolve/enterprise/Spitz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/AccountService.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/AccountService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/AccountTransactionObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/AccountTransactionObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/Failure.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/Failure.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/TransactionalObserverTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/TransactionalObserverTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/Withdrawal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/Withdrawal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/custom/CustomTransactionalObserverTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/custom/CustomTransactionalObserverTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/custom/Giraffe.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/custom/Giraffe.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/custom/GiraffeCustomObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/custom/GiraffeCustomObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/custom/GiraffeObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/custom/GiraffeObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/custom/GiraffeService.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/custom/GiraffeService.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/custom/ObserverExtension.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/custom/ObserverExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/roolback/EjbTestBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/roolback/EjbTestBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/roolback/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/roolback/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/roolback/FooTransactionalObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/roolback/FooTransactionalObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/roolback/TransactionalObserverRollbackTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/event/observer/transactional/roolback/TransactionalObserverRollbackTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2017, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/alternative/metadata/ejb/AlternativeMetadataTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/alternative/metadata/ejb/AlternativeMetadataTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/alternative/metadata/ejb/Pasta.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/alternative/metadata/ejb/Pasta.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/alternative/metadata/ejb/PastaWrapper.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/alternative/metadata/ejb/PastaWrapper.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/alternative/metadata/ejb/ProcessAnnotatedTypeObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/alternative/metadata/ejb/ProcessAnnotatedTypeObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/annotated/delivery/ejb/EnterpriseWithAnnotationsTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/annotated/delivery/ejb/EnterpriseWithAnnotationsTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/annotated/delivery/ejb/Hawk.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/annotated/delivery/ejb/Hawk.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/beanManager/beanAttributes/ejb/CreateBeanAttributesTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/beanManager/beanAttributes/ejb/CreateBeanAttributesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/beanManager/beanAttributes/ejb/Dam.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/beanManager/beanAttributes/ejb/Dam.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/beanManager/beanAttributes/ejb/Lake.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/beanManager/beanAttributes/ejb/Lake.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/beanManager/beanAttributes/ejb/LakeLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/beanManager/beanAttributes/ejb/LakeLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/Cheese.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/Cheese.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/ContainerEventTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/ContainerEventTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/Cow.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/Cow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/CowLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/CowLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/Farm.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/Farm.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/Food.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/Food.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/Milk.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/Milk.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/ProcessAnnotatedTypeObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/ProcessAnnotatedTypeObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/ProcessBeanObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/ProcessBeanObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/ProcessInjectionTargetObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/ProcessInjectionTargetObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/Sheep.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/Sheep.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/SheepInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/SheepInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/SheepLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/SheepLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/Tame.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/jms/ContainerEventTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/jms/ContainerEventTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/jms/ProcessInjectionTargetObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/jms/ProcessInjectionTargetObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/jms/QueueMessageDrivenBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/jms/QueueMessageDrivenBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/jms/Sheep.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/jms/Sheep.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/FullMarathon.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/FullMarathon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/Incremented.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/Incremented.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/IncrementingInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/IncrementingInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/InterceptorExtension.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/InterceptorExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/InterceptorExtensionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/InterceptorExtensionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/LifecycleInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/LifecycleInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/Marathon.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/Marathon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/NumberSource.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/NumberSource.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/Suffixed.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/Suffixed.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/SuffixingInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/SuffixingInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/WordSource.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/interceptors/WordSource.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/events/ContainerLifeCycleEventRuntimeInvocationTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/events/ContainerLifeCycleEventRuntimeInvocationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/events/SimpleAnnotation.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/events/SimpleAnnotation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/events/SimpleBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/events/SimpleBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/events/TestExtension.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/events/TestExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/events/ejb/ContainerLifeCycleEventRuntimeInvocationTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/events/ejb/ContainerLifeCycleEventRuntimeInvocationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/events/ejb/SessionBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/events/ejb/SessionBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/events/ejb/SimpleAnnotation.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/events/ejb/SimpleAnnotation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/events/ejb/SimpleBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/events/ejb/SimpleBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/events/ejb/TestExtension.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/events/ejb/TestExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processBeanAttributes/builtin/ProcessBeanAttributesNotFiredForBuiltinBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processBeanAttributes/builtin/ProcessBeanAttributesNotFiredForBuiltinBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processBeanAttributes/builtin/ProcessBeanAttributesObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processBeanAttributes/builtin/ProcessBeanAttributesObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processBeanAttributes/ejb/Delta.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processBeanAttributes/ejb/Delta.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processBeanAttributes/ejb/VerifyValuesTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processBeanAttributes/ejb/VerifyValuesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processBeanAttributes/ejb/VerifyingExtension.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processBeanAttributes/ejb/VerifyingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionPoint/ee/ProcessInjectionPointFiredTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionPoint/ee/ProcessInjectionPointFiredTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionPoint/ee/TestFilter.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionPoint/ee/TestFilter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionPoint/ee/TestListener.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionPoint/ee/TestListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionPoint/ee/TestServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionPoint/ee/TestServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionPoint/ee/VerifyingExtension.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionPoint/ee/VerifyingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionTarget/ContainerEventTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionTarget/ContainerEventTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionTarget/CustomInjectionTarget.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionTarget/CustomInjectionTarget.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionTarget/Farm.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionTarget/Farm.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionTarget/Fence.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionTarget/Fence.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionTarget/FenceInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionTarget/FenceInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionTarget/ProcessInjectionTargetObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionTarget/ProcessInjectionTargetObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionTarget/Sheep.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionTarget/Sheep.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionTarget/TagLibraryListener.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionTarget/TagLibraryListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionTarget/TestFilter.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionTarget/TestFilter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionTarget/TestListener.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionTarget/TestListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionTarget/TestServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionTarget/TestServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionTarget/TestTagHandler.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processInjectionTarget/TestTagHandler.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/processBean/ejb/Elephant.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/processBean/ejb/Elephant.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/processBean/ejb/ElephantLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/processBean/ejb/ElephantLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/processBean/ejb/ProcessSessionBeanObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/processBean/ejb/ProcessSessionBeanObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/processBean/ejb/ProcessSessionBeanTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/processBean/ejb/ProcessSessionBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/producer/remote/ProducerProcessor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/producer/remote/ProducerProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/producer/remote/RemoteProducerTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/producer/remote/RemoteProducerTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/producer/remote/ServiceBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/producer/remote/ServiceBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/producer/remote/ServiceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/producer/remote/ServiceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/producer/remote/ServiceRemote.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/producer/remote/ServiceRemote.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/AnotherBeanClassToRegister.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/AnotherBeanClassToRegister.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/AnotherManualBeanRegistrationExtension.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/AnotherManualBeanRegistrationExtension.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/BeanClassToRegister.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/BeanClassToRegister.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/BeanRegistrationByExtensionInEarLibraryTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/BeanRegistrationByExtensionInEarLibraryTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/BeanRegistrationByExtensionInNonBeanArchiveTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/BeanRegistrationByExtensionInNonBeanArchiveTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/BeanRegistrationByExtensionInWarLibraryTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/BeanRegistrationByExtensionInWarLibraryTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/Beanie.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/Beanie.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/BeanieType.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/BeanieType.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/BeanieTypeLiteral.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/BeanieTypeLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/DummyObserverExtension.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/DummyObserverExtension.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/EarExtensionsCheck.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/EarExtensionsCheck.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/ManualBeanRegistrationExtension.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/ManualBeanRegistrationExtension.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/TwoBeansOneClassExtension.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/TwoBeansOneClassExtension.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/TwoBeansOneClassTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/TwoBeansOneClassTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/VisibilityOfBeanRegisteredByExtensionFromNonBeanLibraryTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/VisibilityOfBeanRegisteredByExtensionFromNonBeanLibraryTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/WarDummyObserverExtension.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/extensions/registration/WarDummyObserverExtension.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/BuiltInBeansTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/BuiltInBeansTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/MockLoginModule.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/MockLoginModule.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/PrincipalInjectedBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/PrincipalInjectedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/PrincipalInjectedBeanLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/PrincipalInjectedBeanLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/UserTransactionInjectedBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/UserTransactionInjectedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/UserTransactionInjectedBeanLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/UserTransactionInjectedBeanLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/broken/transaction/ContainerManagedTransactionBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/broken/transaction/ContainerManagedTransactionBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/broken/transaction/UserTransactionInvalidInjectionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/broken/transaction/UserTransactionInvalidInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/ee/BuiltinMetadataEEBeanTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/ee/BuiltinMetadataEEBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/ee/Counter.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/ee/Counter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/ee/InterceptorBinding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/ee/InterceptorBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/ee/ServletInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/ee/ServletInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/ee/TestServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/ee/TestServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/session/BakeryProduct.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/session/BakeryProduct.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/session/BakeryProductDecorator.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/session/BakeryProductDecorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/session/Bread.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/session/Bread.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/session/BuiltinMetadataSessionBeanTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/session/BuiltinMetadataSessionBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/session/Frozen.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/session/Frozen.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/session/Yoghurt.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/session/Yoghurt.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/session/YoghurtInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/session/YoghurtInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/servlet/LowercaseConverter.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/servlet/LowercaseConverter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/servlet/LowercaseConverterServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/servlet/LowercaseConverterServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/servlet/ServletContainerBuiltinBeanTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/servlet/ServletContainerBuiltinBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/enterprise/methodOnSessionBean/Apple.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/enterprise/methodOnSessionBean/Apple.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/enterprise/methodOnSessionBean/AppleTree.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/enterprise/methodOnSessionBean/AppleTree.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/enterprise/methodOnSessionBean/AppleTreeLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/enterprise/methodOnSessionBean/AppleTreeLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/enterprise/methodOnSessionBean/DisposalMethodOnSessionBeanTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/enterprise/methodOnSessionBean/DisposalMethodOnSessionBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/enterprise/remoteMethod/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/enterprise/remoteMethod/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/enterprise/remoteMethod/FooDisposal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/enterprise/remoteMethod/FooDisposal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/enterprise/remoteMethod/FooDisposalRemote.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/enterprise/remoteMethod/FooDisposalRemote.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/enterprise/remoteMethod/RemoteBusinessDisposalMethodTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/enterprise/remoteMethod/RemoteBusinessDisposalMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/observes/async/BrokenFoodProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/observes/async/BrokenFoodProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/observes/async/DisposerMethodWithAsyncObservesTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/observes/async/DisposerMethodWithAsyncObservesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/observes/async/Food.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/broken/observes/async/Food.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/ejb/Chicken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/ejb/Chicken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/ejb/Code.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/ejb/Code.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/ejb/CzechChicken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/ejb/CzechChicken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/ejb/DisposerMethodInheritanceTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/ejb/DisposerMethodInheritanceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/ejb/Egg.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/ejb/Egg.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/ejb/Guru.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/ejb/Guru.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/ejb/Programmer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/ejb/Programmer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/ejb/Sumavanka.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/disposal/method/definition/inheritance/ejb/Sumavanka.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/genericStateless/DingoLocal_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/genericStateless/DingoLocal_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/genericStateless/Dingo_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/genericStateless/Dingo_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/genericStateless/GenericStatelessSessionBeanTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/genericStateless/GenericStatelessSessionBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/singletonWithConversationScope/Husky_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/singletonWithConversationScope/Husky_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/singletonWithConversationScope/SingletonWithConversationScopeTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/singletonWithConversationScope/SingletonWithConversationScopeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/singletonWithRequestScope/Greyhound_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/singletonWithRequestScope/Greyhound_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/singletonWithRequestScope/SingletonWithRequestScopeTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/singletonWithRequestScope/SingletonWithRequestScopeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/singletonWithSessionScope/IrishTerrier_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/singletonWithSessionScope/IrishTerrier_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/singletonWithSessionScope/SingletonWithSessionScopeTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/singletonWithSessionScope/SingletonWithSessionScopeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessDecorator/BulldogLocal_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessDecorator/BulldogLocal_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessDecorator/Bulldog_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessDecorator/Bulldog_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessDecorator/Colie.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessDecorator/Colie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessDecorator/DecoratorAnnotatedStatelessSessionBeanTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessDecorator/DecoratorAnnotatedStatelessSessionBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessDecorator/Dog.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessDecorator/Dog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessInterceptor/DalmatianLocal_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessInterceptor/DalmatianLocal_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessInterceptor/Dalmatian_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessInterceptor/Dalmatian_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessInterceptor/InterceptorAnnotatedStatelessSessionBeanTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessInterceptor/InterceptorAnnotatedStatelessSessionBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessWithApplicationScope/DachshundLocal_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessWithApplicationScope/DachshundLocal_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessWithApplicationScope/Dachshund_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessWithApplicationScope/Dachshund_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessWithApplicationScope/StatelessWithApplicationScopeTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessWithApplicationScope/StatelessWithApplicationScopeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessWithConversationScope/BoxerLocal_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessWithConversationScope/BoxerLocal_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessWithConversationScope/Boxer_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessWithConversationScope/Boxer_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessWithConversationScope/StatelessWithConversationScopeTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessWithConversationScope/StatelessWithConversationScopeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessWithRequestScope/BeagleLocal_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessWithRequestScope/BeagleLocal_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessWithRequestScope/Beagle_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessWithRequestScope/Beagle_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessWithRequestScope/StatelessWithRequestScopeTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessWithRequestScope/StatelessWithRequestScopeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessWithSessionScope/BullmastiffLocal_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessWithSessionScope/BullmastiffLocal_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessWithSessionScope/Bullmastiff_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessWithSessionScope/Bullmastiff_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessWithSessionScope/StatelessWithSessionScopeTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/broken/statelessWithSessionScope/StatelessWithSessionScopeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/Ape.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/Ape.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/ApeLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/ApeLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/Dog.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/Dog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/DogLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/DogLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/Elephant.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/Elephant.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/ElephantLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/ElephantLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/EnterpriseBeanDefinitionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/EnterpriseBeanDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/EnterpriseBeanViaXmlTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/EnterpriseBeanViaXmlTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/ExplicitConstructor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/ExplicitConstructor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/ExplicitConstructorSessionBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/ExplicitConstructorSessionBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/Giraffe.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/Giraffe.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/GiraffeLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/GiraffeLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/Labrador.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/Labrador.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/Laika.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/Laika.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/Lion.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/Lion.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/LionLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/LionLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/Monkey.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/Monkey.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/MonkeyLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/MonkeyLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/NoParamConstructorSessionBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/NoParamConstructorSessionBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/Pitbull.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/Pitbull.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/PitbullLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/PitbullLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/Polar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/Polar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/PolarBear.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/PolarBear.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/PolarBearLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/PolarBearLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/Retriever.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/Retriever.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/SimpleBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/SimpleBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/Tame.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/Bar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/Collie.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/Collie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/DogLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/DogLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/DogRemote.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/DogRemote.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/DoggieRemote.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/DoggieRemote.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/Pitbull.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/Pitbull.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/RemoteInterfaceNotInAPITypesTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/RemoteInterfaceNotInAPITypesTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/SuperBar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/SuperBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/Tame.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/AlteStadt.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/AlteStadt.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/DirectOrderProcessor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/DirectOrderProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/DirectOrderProcessorLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/DirectOrderProcessorLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/EnterpriseBeanLifecycleTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/EnterpriseBeanLifecycleTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/FrankfurtAmMain.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/FrankfurtAmMain.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/GeschichtslosStadt.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/GeschichtslosStadt.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/Giessen.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/Giessen.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/GrossStadt.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/GrossStadt.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/GutenbergMuseum.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/GutenbergMuseum.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/Heidelburg.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/Heidelburg.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/Important.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/Important.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/IndirectOrderProcessor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/IndirectOrderProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/IntermediateOrderProcessor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/IntermediateOrderProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/Kassel.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/Kassel.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/KleinStadt.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/KleinStadt.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/LandgraffenSchloss.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/LandgraffenSchloss.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/Mainz.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/Mainz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/Marburg.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/Marburg.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/NeueStadt.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/NeueStadt.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/OrderProcessor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/OrderProcessor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/OrderProcessorLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/OrderProcessorLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/RoemerPassage.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/RoemerPassage.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/Schloss.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/Schloss.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/SchoeneStadt.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/SchoeneStadt.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/UniStadt.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/lifecycle/UniStadt.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/remove/DependentSessionBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/remove/DependentSessionBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/remove/DependentSessionInterface.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/remove/DependentSessionInterface.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/remove/EnterpriseBeanRemoveMethodTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/remove/EnterpriseBeanRemoveMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/remove/SessionScopedSessionBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/remove/SessionScopedSessionBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/remove/SessionScopedSessionInterface.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/remove/SessionScopedSessionInterface.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/remove/StateKeeper.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/remove/StateKeeper.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/ejb/AndalusianChicken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/ejb/AndalusianChicken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/ejb/EjbInitializerMethodTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/ejb/EjbInitializerMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/ejb/LocalChicken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/initializer/ejb/LocalChicken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/enterprise/nonstatic/FooLocal_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/enterprise/nonstatic/FooLocal_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/enterprise/nonstatic/Foo_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/enterprise/nonstatic/Foo_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/enterprise/nonstatic/NonStaticFieldOfSessionBeanTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/enterprise/nonstatic/NonStaticFieldOfSessionBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/enterprise/nonstatic/Number.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/broken/enterprise/nonstatic/Number.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/enterprise/Chicken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/enterprise/Chicken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/enterprise/ChickenLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/enterprise/ChickenLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/enterprise/Egg.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/enterprise/Egg.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/enterprise/EnterpriseProducerFieldDefinitionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/enterprise/EnterpriseProducerFieldDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/enterprise/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/field/definition/enterprise/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/enterprise/nonbusiness/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/enterprise/nonbusiness/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/enterprise/nonbusiness/FooProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/enterprise/nonbusiness/FooProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/enterprise/nonbusiness/FooProducerLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/enterprise/nonbusiness/FooProducerLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/enterprise/nonbusiness/ProducerMethodNotBusinessMethodTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/enterprise/nonbusiness/ProducerMethodNotBusinessMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/enterprise/remoteMethod/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/enterprise/remoteMethod/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/enterprise/remoteMethod/FooProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/enterprise/remoteMethod/FooProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/enterprise/remoteMethod/FooProducerRemote.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/enterprise/remoteMethod/FooProducerRemote.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/enterprise/remoteMethod/RemoteBusinessProducerMethodTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/broken/enterprise/remoteMethod/RemoteBusinessProducerMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/AndalusianChicken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/AndalusianChicken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/AndalusianChickenLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/AndalusianChickenLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/Apple.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/Apple.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/AppleTree.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/AppleTree.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/AppleTreeLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/AppleTreeLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/Chicken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/Chicken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/ChickenLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/ChickenLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/Egg.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/Egg.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/EnterpriseProducerMethodDefinitionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/EnterpriseProducerMethodDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/GrannySmithAppleTree.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/GrannySmithAppleTree.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/LightYellow.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/LightYellow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/LightYellowPearTree.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/LightYellowPearTree.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/LightYellowPearTreeLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/LightYellowPearTreeLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/Pear.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/Pear.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/PearTree.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/PearTree.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/PearTreeLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/PearTreeLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/YellowPearTree.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/YellowPearTree.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/Yummy.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/producer/method/definition/enterprise/Yummy.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/ee/EnterpriseBeanNotDiscoveredAsManagedBeanTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/ee/EnterpriseBeanNotDiscoveredAsManagedBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/ee/EnterpriseBeanObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/ee/EnterpriseBeanObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/ee/MockEnterpriseBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/ee/MockEnterpriseBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/ee/MockServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/ee/MockServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/ee/MockServletContextListener.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/ee/MockServletContextListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/ee/MockServletRequestListener.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/ee/MockServletRequestListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/ee/MockUIComponent.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/definition/ee/MockUIComponent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/ee/components/IntrospectServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/ee/components/IntrospectServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/ee/components/JavaEEComponentsTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/ee/components/JavaEEComponentsTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/ee/components/Ping.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/ee/components/Ping.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/ee/components/Tame.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/ee/components/Tame.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/ee/components/Wild.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/ee/components/Wild.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/name/Another.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/name/Another.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/name/ResourceDefinitionWithNameTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/name/ResourceDefinitionWithNameTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/name/ResourceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/name/ResourceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/Another.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/Another.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/ResourceDefinitionWithDifferentTypeTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/ResourceDefinitionWithDifferentTypeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/ResourceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/ResourceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/ejb/Bean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/ejb/Bean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/ejb/BeanRemote.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/ejb/BeanRemote.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/ejb/Lazy.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/ejb/Lazy.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/ejb/ResourceDefinitionWithDifferentTypeTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/ejb/ResourceDefinitionWithDifferentTypeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/ejb/ResourceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/ejb/ResourceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/env/Greeting.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/env/Greeting.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/env/ResourceDefinitionWithDifferentTypeTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/env/ResourceDefinitionWithDifferentTypeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/env/ResourceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/env/ResourceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/persistence/context/Database.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/persistence/context/Database.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/persistence/context/ResourceDefinitionWithDifferentTypeTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/persistence/context/ResourceDefinitionWithDifferentTypeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/persistence/context/ResourceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/persistence/context/ResourceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/persistence/unit/Database.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/persistence/unit/Database.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/persistence/unit/ResourceDefinitionWithDifferentTypeTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/persistence/unit/ResourceDefinitionWithDifferentTypeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/persistence/unit/ResourceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/broken/type/persistence/unit/ResourceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/AnotherInterface.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/AnotherInterface.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/Bean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/Bean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/BeanRemote.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/BeanRemote.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/EjbInjectionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/EjbInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/Lazy.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/Lazy.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/ManagedBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/ManagedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/Monitor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/Monitor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/ResourceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/ResourceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/staticProducer/Bean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/staticProducer/Bean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/staticProducer/EjbInjectionStaticProducerFieldTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/staticProducer/EjbInjectionStaticProducerFieldTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/staticProducer/Lazy.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/staticProducer/Lazy.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/staticProducer/ManagedBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/staticProducer/ManagedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/staticProducer/ResourceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/staticProducer/ResourceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/env/BooleanResourceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/env/BooleanResourceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2019, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/env/EnvInjectionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/env/EnvInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/env/Greeting.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/env/Greeting.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/env/GreetingBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/env/GreetingBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/env/ResourceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/env/ResourceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/env/staticProducer/EnvInjectionStaticProducerFieldTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/env/staticProducer/EnvInjectionStaticProducerFieldTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/env/staticProducer/Greeting.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/env/staticProducer/Greeting.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/env/staticProducer/GreetingBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/env/staticProducer/GreetingBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/env/staticProducer/ResourceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/env/staticProducer/ResourceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/Database.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/Database.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/ManagedBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/ManagedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/PersistenceContextInjectionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/PersistenceContextInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/ResourceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/ResourceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/ServiceBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/ServiceBean.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2010, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/ServiceBeanImpl.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/ServiceBeanImpl.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2010, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/staticProducer/Database.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/staticProducer/Database.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/staticProducer/ManagedBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/staticProducer/ManagedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/staticProducer/PersistenceInjectionStaticProducerFieldTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/staticProducer/PersistenceInjectionStaticProducerFieldTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/staticProducer/ResourceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/staticProducer/ResourceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/staticProducer/ServiceBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/staticProducer/ServiceBean.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2010, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/staticProducer/ServiceBeanImpl.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/staticProducer/ServiceBeanImpl.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2010, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/resource/Another.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/resource/Another.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/resource/InjectionOfResourceTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/resource/InjectionOfResourceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/resource/ManagedBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/resource/ManagedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/resource/ResourceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/resource/ResourceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/resource/staticProducer/Another.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/resource/staticProducer/Another.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/resource/staticProducer/InjectionOfResourceStaticProducerFieldTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/resource/staticProducer/InjectionOfResourceStaticProducerFieldTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/resource/staticProducer/ManagedBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/resource/staticProducer/ManagedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/resource/staticProducer/ResourceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/resource/staticProducer/ResourceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/AppleEjb.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/AppleEjb.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/Cheap.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/Cheap.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/Citrus.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/Citrus.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/CitrusEjb.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/CitrusEjb.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/Expensive.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/Expensive.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/FirstLevel.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/FirstLevel.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/Fruit.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/Fruit.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/FruitEjb.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/FruitEjb.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/InitializerMethodInheritanceTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/InitializerMethodInheritanceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/Lemon.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/Lemon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/Orange.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/Orange.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/OrangeEjb.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/OrangeEjb.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/PriceProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/PriceProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/SecondLevel.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/initializer/SecondLevel.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/Animal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/Building.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/Building.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/BuildingLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/BuildingLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/EnterpriseBeanSpecializationTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/EnterpriseBeanSpecializationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/FarmEquipment.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/FarmEquipment.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/Farmer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/Farmer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/FarmerLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/FarmerLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/Landowner.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/Landowner.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/Lazy.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/Lazy.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/LazyFarmer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/LazyFarmer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/LazyFarmerLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/LazyFarmerLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/Office.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/Office.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/OfficeLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/OfficeLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/TractorLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/TractorLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/Waste.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/Waste.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/Yard.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/Yard.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/YardInterface.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/YardInterface.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/managedbean/DirectlyExtendsSimpleBeanTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/managedbean/DirectlyExtendsSimpleBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/managedbean/FarmEquipment.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/managedbean/FarmEquipment.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/managedbean/TractorLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/managedbean/TractorLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/managedbean/Tractor_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/managedbean/Tractor_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/nothing/CowLocal_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/nothing/CowLocal_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/nothing/Cow_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/nothing/Cow_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/nothing/DirectlyExtendsNothingTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/nothing/DirectlyExtendsNothingTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/sessionbean/LoginAction.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/sessionbean/LoginAction.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/sessionbean/LoginActionBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/sessionbean/LoginActionBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/sessionbean/Mock.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/sessionbean/Mock.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/sessionbean/MockLoginActionBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/sessionbean/MockLoginActionBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/sessionbean/SessionBeanSpecializingSessionBeanWithClientViewTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/extend/sessionbean/SessionBeanSpecializingSessionBeanWithClientViewTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/name/FarmYard_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/name/FarmYard_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/name/SameNameTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/name/SameNameTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/name/Yard.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/name/Yard.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/name/YardInterface.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/name/YardInterface.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/twobeans/Farmer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/twobeans/Farmer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/twobeans/FarmerInterface.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/twobeans/FarmerInterface.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/twobeans/FishFarmer_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/twobeans/FishFarmer_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/twobeans/Landowner.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/twobeans/Landowner.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/twobeans/SheepFarmer_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/twobeans/SheepFarmer_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/twobeans/TwoBeansSpecializeTheSameBeanTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/broken/twobeans/TwoBeansSpecializeTheSameBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/producer/method/enterprise/EnterpriseProducerMethodSpecializationTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/producer/method/enterprise/EnterpriseProducerMethodSpecializationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/producer/method/enterprise/Expensive.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/producer/method/enterprise/Expensive.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/producer/method/enterprise/JewelryShop.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/producer/method/enterprise/JewelryShop.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/producer/method/enterprise/Necklace.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/producer/method/enterprise/Necklace.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/producer/method/enterprise/Product.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/producer/method/enterprise/Product.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/producer/method/enterprise/Shop.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/producer/method/enterprise/Shop.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/producer/method/enterprise/Sparkly.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/producer/method/enterprise/Sparkly.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/simple/broken/extendejb/FarmEquipment.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/simple/broken/extendejb/FarmEquipment.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/simple/broken/extendejb/FarmEquipmentLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/simple/broken/extendejb/FarmEquipmentLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/simple/broken/extendejb/SpecializingBeanExtendsEnterpriseBeanTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/simple/broken/extendejb/SpecializingBeanExtendsEnterpriseBeanTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/simple/broken/extendejb/Tractor_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/simple/broken/extendejb/Tractor_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/ee/FinalClassMethodLevelInterceptorTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/ee/FinalClassMethodLevelInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/ee/FinalMethodClassLevelInterceptorTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/ee/FinalMethodClassLevelInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/ee/FinalMethodClassLevelMissile.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/ee/FinalMethodClassLevelMissile.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/ee/FinalMethodClassLevelMissileLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/ee/FinalMethodClassLevelMissileLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/ee/FinalMethodMethodLevelInterceptorTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/ee/FinalMethodMethodLevelInterceptorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/ee/FinalMethodMethodLevelMissile.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/ee/FinalMethodMethodLevelMissile.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/ee/FinalMethodMethodLevelMissileLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/ee/FinalMethodMethodLevelMissileLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/ee/FooBinding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/ee/FooBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/ee/MissileInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/broken/finalClassInterceptor/ee/MissileInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/interceptorOrder/Airborne.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/interceptorOrder/Airborne.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/interceptorOrder/Missile.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/interceptorOrder/Missile.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/interceptorOrder/MissileInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/interceptorOrder/MissileInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/interceptorOrder/MissileLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/interceptorOrder/MissileLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/interceptorOrder/RadarInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/interceptorOrder/RadarInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/interceptorOrder/SessionBeanInterceptorOrderTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/interceptorOrder/SessionBeanInterceptorOrderTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/jms/MessageDrivenBeanInterceptorInvocationTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/jms/MessageDrivenBeanInterceptorInvocationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/jms/MessageDrivenMissile.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/jms/MessageDrivenMissile.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/jms/Missile.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/jms/Missile.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/jms/MissileInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/jms/MissileInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/jms/SimpleMessageProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/jms/SimpleMessageProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/nonContextualReference/Airborne.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/nonContextualReference/Airborne.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/nonContextualReference/Anchor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/nonContextualReference/Anchor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/nonContextualReference/AnchorInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/nonContextualReference/AnchorInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/nonContextualReference/Cruiser.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/nonContextualReference/Cruiser.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/nonContextualReference/Missile.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/nonContextualReference/Missile.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/nonContextualReference/MissileInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/nonContextualReference/MissileInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/nonContextualReference/MissileLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/nonContextualReference/MissileLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/nonContextualReference/SessionBeanInterceptorOnNonContextualEjbReferenceTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/nonContextualReference/SessionBeanInterceptorOnNonContextualEjbReferenceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/nonContextualReference/Ship.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/nonContextualReference/Ship.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/nonContextualReference/Waterborne.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/nonContextualReference/Waterborne.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/simpleInterception/Airborne.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/simpleInterception/Airborne.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/simpleInterception/Missile.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/simpleInterception/Missile.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/simpleInterception/MissileInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/simpleInterception/MissileInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/simpleInterception/MissileLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/simpleInterception/MissileLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/simpleInterception/Rocket.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/simpleInterception/Rocket.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/simpleInterception/SessionBeanInterceptorDefinitionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/simpleInterception/SessionBeanInterceptorDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/Cactus.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/Cactus.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/Culinary.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/Culinary.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/European.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/European.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/Flower.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/Flower.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/ForgetMeNot.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/ForgetMeNot.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/Grass.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/Grass.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/GuardedBySquirrel.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/GuardedBySquirrel.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/GuardedByWoodpecker.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/GuardedByWoodpecker.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/InterceptorBindingInheritanceTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/InterceptorBindingInheritanceTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/Opuncia.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/Opuncia.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/Ping.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/Ping.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/Plant.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/Plant.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/PongPlant.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/PongPlant.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/Shrub.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/Shrub.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/SquirrelInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/SquirrelInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/Tree.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/Tree.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/WaterChestnut.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/WaterChestnut.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/WoodForgetMeNot.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/WoodForgetMeNot.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/WoodpeckerInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/inheritance_ee/WoodpeckerInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/lifecycle/enterprise/order/Airborne.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/lifecycle/enterprise/order/Airborne.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/lifecycle/enterprise/order/AnotherInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/lifecycle/enterprise/order/AnotherInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/lifecycle/enterprise/order/EnterpriseLifecycleInterceptorDefinitionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/lifecycle/enterprise/order/EnterpriseLifecycleInterceptorDefinitionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/lifecycle/enterprise/order/Missile.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/lifecycle/enterprise/order/Missile.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/lifecycle/enterprise/order/MissileInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/lifecycle/enterprise/order/MissileInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/lifecycle/enterprise/order/Weapon.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/lifecycle/enterprise/order/Weapon.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ejb/InterceptorInvocationTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ejb/InterceptorInvocationTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ejb/Timing.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ejb/Timing.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/AbstractInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/AbstractInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/Dao.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/Dao.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/DummyDao.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/DummyDao.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/EnterpriseInterceptorOrderingTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/EnterpriseInterceptorOrderingTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/GlobalInterceptorOrderingTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/GlobalInterceptorOrderingTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/GloballyEnabledInterceptor1.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/GloballyEnabledInterceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/GloballyEnabledInterceptor2.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/GloballyEnabledInterceptor2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/GloballyEnabledInterceptor3.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/GloballyEnabledInterceptor3.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/GloballyEnabledInterceptor4.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/GloballyEnabledInterceptor4.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/GloballyEnabledInterceptor5.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/GloballyEnabledInterceptor5.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/LegacyInterceptor1.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/LegacyInterceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/LegacyInterceptor2.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/LegacyInterceptor2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/LegacyInterceptor3.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/LegacyInterceptor3.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/Service.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/Service.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/Transactional.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/Transactional.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/WebApplicationGlobalInterceptor1.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/interceptors/ordering/global/WebApplicationGlobalInterceptor1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/incontainer/Car.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/incontainer/Car.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/incontainer/ClientProxyTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/incontainer/ClientProxyTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/incontainer/Garage.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/incontainer/Garage.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/incontainer/TestServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/incontainer/TestServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/integration/ClientProxyTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/integration/ClientProxyTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/integration/Fox.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/integration/Fox.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/integration/Tuna.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/integration/Tuna.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/integration/TunedTuna.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/integration/TunedTuna.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/ambiguous/ear/Animal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/ambiguous/ear/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/ambiguous/ear/Bar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/ambiguous/ear/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/ambiguous/ear/Cat.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/ambiguous/ear/Cat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/ambiguous/ear/Dog.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/ambiguous/ear/Dog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/ambiguous/ear/MultiModuleSessionBeanAmbiguousDependencyTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/dependency/resolution/broken/ambiguous/ear/MultiModuleSessionBeanAmbiguousDependencyTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/el/integration/IntegrationWithUnifiedELTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/el/integration/IntegrationWithUnifiedELTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/el/integration/Sheep.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/el/integration/Sheep.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/InjectionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/InjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/MegaPoorHenHouse.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/MegaPoorHenHouse.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/PoorHenHouse.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/PoorHenHouse.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/ejb/DeluxeHenHouse.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/ejb/DeluxeHenHouse.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/ejb/HenHouse.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/ejb/HenHouse.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/ejb/SessionBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/ejb/SessionBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/DeluxeHenHouse.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/DeluxeHenHouse.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/DeluxeHenHouseLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/DeluxeHenHouseLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/Farm.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/Farm.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/FarmInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/FarmInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/FarmLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/FarmLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/Fox.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/Fox.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/HenHouse.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/HenHouse.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/InjectedSessionBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/InjectedSessionBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/InjectedSessionBeanLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/InjectedSessionBeanLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/MegaPoorHenHouse.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/MegaPoorHenHouse.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/MegaPoorHenHouseLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/MegaPoorHenHouseLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/PoorHenHouse.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/PoorHenHouse.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/SessionBeanInjectionOrderingTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/SessionBeanInjectionOrderingTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/SessionBeanInjectionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/SessionBeanInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/Sheep.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/Sheep.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/SuperInjectedSessionBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/SuperInjectedSessionBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/chain/Bar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/chain/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/chain/Baz.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/chain/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/chain/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/chain/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/chain/Qux.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/chain/Qux.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/chain/SessionBeanInjectionChainTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/enterprise/chain/SessionBeanInjectionChainTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/ContainerEventTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/ContainerEventTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/CreationalContextForNonContextualTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/CreationalContextForNonContextualTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/Farm.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/Farm.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/InjectionIntoNonContextualComponentTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/InjectionIntoNonContextualComponentTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/ProcessAnnotatedTypeObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/ProcessAnnotatedTypeObserver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/SessionBean.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/SessionBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/Sheep.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/Sheep.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/TagLibraryListener.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/TagLibraryListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/TestFilter.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/TestFilter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/TestListener.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/TestListener.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/TestServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/TestServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/TestTagHandler.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/TestTagHandler.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/broken/ambiguous/AmbiguousInjectionIntoNonContextualComponentTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/broken/ambiguous/AmbiguousInjectionIntoNonContextualComponentTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/broken/ambiguous/Animal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/broken/ambiguous/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/broken/ambiguous/Cow.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/broken/ambiguous/Cow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/broken/ambiguous/TestServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/broken/ambiguous/TestServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/broken/unsatisfied/TestServlet.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/broken/unsatisfied/TestServlet.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/broken/unsatisfied/UnsatisfiedInjectionIntoNonContextualComponentTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/broken/unsatisfied/UnsatisfiedInjectionIntoNonContextualComponentTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/persistence/PersistenceResourceInjectionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/persistence/PersistenceResourceInjectionTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/persistence/Persistor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/persistence/Persistor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/persistence/SpecialPersistor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/persistence/SpecialPersistor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/broken/not/bean/InjectionPointTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/broken/not/bean/InjectionPointTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/broken/not/bean/TestServlet_Broken.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/broken/not/bean/TestServlet_Broken.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/non/contextual/Bar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/non/contextual/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/non/contextual/Baz.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/non/contextual/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/non/contextual/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/non/contextual/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/non/contextual/NonContextualInjectionPointTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/injectionpoint/non/contextual/NonContextualInjectionPointTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/jndi/JndiBeanManagerInjected.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/jndi/JndiBeanManagerInjected.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/jndi/ManagerTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/jndi/ManagerTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/jndi/ManagerTestEar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/jndi/ManagerTestEar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/AfterDeploymentValidationObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/AfterDeploymentValidationObserver.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/Alpha.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/Alpha.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/Bar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/Baz.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/Baz.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/Bravo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/Bravo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/CDIProviderInitTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/CDIProviderInitTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/Charlie.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/Charlie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/Marker.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/Marker.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/MarkerObtainerBda1.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/MarkerObtainerBda1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/MarkerObtainerBda2.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/MarkerObtainerBda2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/MarkerObtainerNonBda.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/MarkerObtainerNonBda.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/MarkerObtainerWar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/MarkerObtainerWar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/NonBdaAfterDeploymentValidationObserver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/init/NonBdaAfterDeploymentValidationObserver.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/runtime/Alpha.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/runtime/Alpha.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/runtime/AlphaLocator.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/runtime/AlphaLocator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/runtime/Bravo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/runtime/Bravo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/runtime/BravoLocator.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/runtime/BravoLocator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/runtime/BravoMarker.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/runtime/BravoMarker.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/runtime/CDIProviderRuntimeTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/runtime/CDIProviderRuntimeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/runtime/Powerful.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/runtime/Powerful.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/runtime/PowerfulLiteral.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/manager/provider/runtime/PowerfulLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/AlternativeEjbFoo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/AlternativeEjbFoo.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/AlternativeFoo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/AlternativeFoo.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/Bar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/CashEjbFoo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/CashEjbFoo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/CashFoo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/CashFoo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/EjbFoo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/EjbFoo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/EjbFooLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/EjbFooLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/EnabledManagedBeanInjectionAvailability02Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/EnabledManagedBeanInjectionAvailability02Test.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/EnabledManagedBeanInjectionAvailabilityTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/EnabledManagedBeanInjectionAvailabilityTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/EnabledProducerFieldInjectionAvailability02Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/EnabledProducerFieldInjectionAvailability02Test.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/EnabledProducerFieldInjectionAvailabilityTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/EnabledProducerFieldInjectionAvailabilityTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/EnabledProducerMethodInjectionAvailability02Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/EnabledProducerMethodInjectionAvailability02Test.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/EnabledProducerMethodInjectionAvailabilityTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/EnabledProducerMethodInjectionAvailabilityTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/EnabledSessionBeanInjectionAvailability02Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/EnabledSessionBeanInjectionAvailability02Test.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/EnabledSessionBeanInjectionAvailabilityTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/EnabledSessionBeanInjectionAvailabilityTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/Enterprise.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/Enterprise.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/Foo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/FooFieldProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/FooFieldProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/FooMethodProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/FooMethodProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/InterModuleELResolution02Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/InterModuleELResolution02Test.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/InterModuleELResolutionTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/InterModuleELResolutionTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/InterModuleLookup02Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/InterModuleLookup02Test.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/InterModuleLookupTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/InterModuleLookupTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/ManagedFoo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/ManagedFoo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/PaymentEjbFoo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/PaymentEjbFoo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/PaymentFoo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/PaymentFoo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/ProducedFoo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/ProducedFoo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/SelectedAlternativeManagedBeanInjectionAvailability02Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/SelectedAlternativeManagedBeanInjectionAvailability02Test.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/SelectedAlternativeManagedBeanInjectionAvailabilityTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/SelectedAlternativeManagedBeanInjectionAvailabilityTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/SelectedAlternativeSessionBeanInjectionAvailability02Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/SelectedAlternativeSessionBeanInjectionAvailability02Test.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/SelectedAlternativeSessionBeanInjectionAvailabilityTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/SelectedAlternativeSessionBeanInjectionAvailabilityTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/SpecializedBeanInjectionNotAvailable02Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/SpecializedBeanInjectionNotAvailable02Test.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/SpecializedBeanInjectionNotAvailableTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/SpecializedBeanInjectionNotAvailableTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/SpecializedProducerMethodInjectionNotAvailable02Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/SpecializedProducerMethodInjectionNotAvailable02Test.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/SpecializedProducerMethodInjectionNotAvailableTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/SpecializedProducerMethodInjectionNotAvailableTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/SpecializingFooMethodProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/SpecializingFooMethodProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/Standard.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/Standard.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/WebBar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/WebBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/WebFooELResolver.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/WebFooELResolver.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/WebFooLookup.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/WebFooLookup.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/WebPaymentBar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/WebPaymentBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/WebPaymentEjbBar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/WebPaymentEjbBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/broken/BrokenBar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/broken/BrokenBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/broken/BrokenFoo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/broken/BrokenFoo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/broken/BrokenProducedFoo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/broken/BrokenProducedFoo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/broken/BrokenWebBar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/broken/BrokenWebBar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/broken/DisabledEjbFoo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/broken/DisabledEjbFoo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/broken/DisabledFooFieldProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/broken/DisabledFooFieldProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/broken/DisabledFooMethodProducer.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/broken/DisabledFooMethodProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/broken/DisabledProducerFieldInjectionNotAvailableTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/broken/DisabledProducerFieldInjectionNotAvailableTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/broken/DisabledProducerMethodInjectionNotAvailableTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/broken/DisabledProducerMethodInjectionNotAvailableTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/broken/DisabledSessionBeanInjectionNotAvailableTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/broken/DisabledSessionBeanInjectionNotAvailableTest.java
@@ -1,7 +1,6 @@
 /*
  * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/broken/EjbFooLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/broken/EjbFooLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/interceptors/Animal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/interceptors/Animal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/interceptors/Bar.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/interceptors/Bar.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/interceptors/BarBinding.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/interceptors/BarBinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/interceptors/BarInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/interceptors/BarInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/interceptors/BarSuperInterceptor.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/interceptors/BarSuperInterceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/interceptors/Cat.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/interceptors/Cat.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/interceptors/Checker.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/interceptors/Checker.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/interceptors/Cow.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/interceptors/Cow.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/interceptors/Dog.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/interceptors/Dog.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/interceptors/InterceptorModularityTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/interceptors/InterceptorModularityTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/Alpha.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/Alpha.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/Bravo.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/Bravo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/Charlie.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/Charlie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/Connector.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/Connector.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/Handler.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/Handler.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/LowercaseHandler.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/LowercaseHandler.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/SpecializationModularity01Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/SpecializationModularity01Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/SpecializationModularity02Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/SpecializationModularity02Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/SpecializationModularity03Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/SpecializationModularity03Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/SpecializationModularity04Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/SpecializationModularity04Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/SpecializationModularity05Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/SpecializationModularity05Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/SpecializationModularity06Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/SpecializationModularity06Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/SpecializationModularity07Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/SpecializationModularity07Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/UppercaseHandler.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/UppercaseHandler.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/AlternativeSpecializedFactory.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/AlternativeSpecializedFactory.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Factory.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Factory.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/FactoryEvent.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/FactoryEvent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/InjectedBean1.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/InjectedBean1.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/InjectedBean2.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/InjectedBean2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Product.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Product.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Specialization01Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Specialization01Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Specialization02Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Specialization02Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Specialization03Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Specialization03Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Specialization04Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Specialization04Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Specialization05Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Specialization05Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Specialization06Test.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/modules/specialization/alternative/Specialization06Test.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/interceptor/ejb/Capercaillie.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/interceptor/ejb/Capercaillie.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/interceptor/ejb/CapercaillieLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/interceptor/ejb/CapercaillieLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/interceptor/ejb/EnterpriseResolutionByTypeTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/interceptor/ejb/EnterpriseResolutionByTypeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/interceptor/ejb/ScottishBirdLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/interceptor/ejb/ScottishBirdLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/vetoed/enterprise/Elephant.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/vetoed/enterprise/Elephant.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/vetoed/enterprise/ElephantLocal.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/vetoed/enterprise/ElephantLocal.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/vetoed/enterprise/EnterpriseVetoedTest.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/vetoed/enterprise/EnterpriseVetoedTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/vetoed/enterprise/Gecko.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/vetoed/enterprise/Gecko.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/vetoed/enterprise/ModifyingExtension.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/vetoed/enterprise/ModifyingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/vetoed/enterprise/VerifyingExtension.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/vetoed/enterprise/VerifyingExtension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/vetoed/enterprise/aquarium/Piranha.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/vetoed/enterprise/aquarium/Piranha.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/jboss/cdi/tck/tests/vetoed/enterprise/aquarium/package-info.java
+++ b/web/src/main/java/org/jboss/cdi/tck/tests/vetoed/enterprise/aquarium/package-info.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat Middleware LLC, and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/test/java/org/jboss/cdi/tck/test/ExclusionListsTest.java
+++ b/web/src/test/java/org/jboss/cdi/tck/test/ExclusionListsTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/test/java/org/jboss/cdi/tck/test/porting/DummyBeans.java
+++ b/web/src/test/java/org/jboss/cdi/tck/test/porting/DummyBeans.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/test/java/org/jboss/cdi/tck/test/porting/DummyContexts.java
+++ b/web/src/test/java/org/jboss/cdi/tck/test/porting/DummyContexts.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/test/java/org/jboss/cdi/tck/test/porting/DummyContextuals.java
+++ b/web/src/test/java/org/jboss/cdi/tck/test/porting/DummyContextuals.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/test/java/org/jboss/cdi/tck/test/porting/DummyCreationalContexts.java
+++ b/web/src/test/java/org/jboss/cdi/tck/test/porting/DummyCreationalContexts.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/test/java/org/jboss/cdi/tck/test/porting/DummyEL.java
+++ b/web/src/test/java/org/jboss/cdi/tck/test/porting/DummyEL.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/descriptors/ejb/EjbJarDescriptorBuilderTest.java
+++ b/web/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/descriptors/ejb/EjbJarDescriptorBuilderTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/descriptors/ejb/Input.java
+++ b/web/src/test/java/org/jboss/cdi/tck/test/shrinkwrap/descriptors/ejb/Input.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2012, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Remove the references to the use of the authors tag and copyright.txt as a record of contributors.

There isn't actually a notices file in this repository, but there [should be][req-files] and I think it should be the same as the one in the cdi spec repo. I'll add it in a different PR to keep it separate from this change which hits a lot of files.

A few of the copyright headers had the lines wrapped in different places. I've put those changes in a different commit so that they can be reviewed separately.

For #525 

Similar CDI repo change: jakartaee/cdi#762

[req-files]: https://www.eclipse.org/projects/handbook/#legaldoc-repo