### PR TITLE
Fix URLs for inject repositories

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -18,13 +18,13 @@ cdi-tck - Project repository hosted on GitHub.
 `clone: https://github.com/jakartaee/cdi-tck.git`
 
 injection-api - Project repository hosted on GitHub.
-`clone: https://github.com/jakartaee/injection-api.git`
+`clone: https://github.com/jakartaee/inject.git`
 
 injection-spec - Project repository hosted on GitHub.
-`clone: https://github.com/jakartaee/injection-spec.git`
+`clone: https://github.com/jakartaee/inject-spec.git`
 
 injection-tck - Project repository hosted on GitHub.
-`clone: https://github.com/jakartaee/injection-tck.git`
+`clone: https://github.com/jakartaee/inject-tck.git`
 
 === Legacy CPL Licensed CDI Respositories
 cdi-tck-cpl - Project repository hosted on GitHub.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -29,14 +29,14 @@ The project maintains the following source code repositories:
 
 * https://github.com/jakartaee/cdi
 * https://github.com/jakartaee/cdi-tck
-* https://github.com/jakartaee/injection-api
-* https://github.com/jakartaee/injection-spec
-* https://github.com/jakartaee/injection-tck
+* https://github.com/jakartaee/inject
+* https://github.com/jakartaee/inject-spec
+* https://github.com/jakartaee/inject-tck
 
 The project also maintains the following legacy CPL licensed source code repositories:
 
-* https://github.com/eclipse-ee4j/cdi-cpl.git
-* https://github.com/eclipse-ee4j/cdi-tck-cpl.git
+* https://github.com/eclipse-ee4j/cdi-cpl
+* https://github.com/eclipse-ee4j/cdi-tck-cpl
 
 ## Third-party Content
 


### PR DESCRIPTION
I got the new URLs for the inject spec wrong in #541, which @Ladicek spotted in jakartaee/cdi#766.